### PR TITLE
Improve chat message color contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --bot-color: #e0e0e0;
-  --user-color: #cce5ff;
+  --bot-color: #f5f5f5;
+  --user-color: #91c9ff;
   --max-width: 600px;
   font-size: 16px;
 }
@@ -42,6 +42,7 @@ body {
   line-height: 1.4;
   width: fit-content;
   max-width: 90%;
+  color: #000;
 }
 
 .message.bot .content {


### PR DESCRIPTION
## Summary
- increase contrast for bot and user message backgrounds and fix text color for better readability

## Testing
- `python - <<'PY'
import re
from pathlib import Path
css = Path('styles.css').read_text()
colors = dict(re.findall(r'--(bot|user)-color:\s*(#[0-9a-fA-F]{6})', css))

def contrast_ratio(fg, bg):
    def to_linear(c):
        c=c/255
        return c/12.92 if c<=0.03928 else ((c+0.055)/1.055)**2.4
    rgb1=[int(fg[i:i+2],16) for i in (0,2,4)]
    rgb2=[int(bg[i:i+2],16) for i in (0,2,4)]
    L1=0.2126*to_linear(rgb1[0])+0.7152*to_linear(rgb1[1])+0.0722*to_linear(rgb1[2])
    L2=0.2126*to_linear(rgb2[0])+0.7152*to_linear(rgb2[1])+0.0722*to_linear(rgb2[2])
    return (max(L1,L2)+0.05)/(min(L1,L2)+0.05)
for key,color in colors.items():
    ratio = contrast_ratio('000000', color[1:])
    print(key, color, 'ratio', round(ratio,2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a08aaf46f0832b8c8aa202e3189e43