### PR TITLE
Add disabled state styling for button group

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,13 @@ body {
   font-size: 1rem;
 }
 
+.btn-group button:disabled {
+  background: #ddd;
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
 /* Overlay de consentimento */
 .overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- style disabled buttons in btn-group with gray background, not-allowed cursor, no pointer events, and reduced opacity

## Testing
- `python validate_rules.py`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ROBOTTO/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a08c871380832bae9949d22a8e77d6