### PR TITLE
Add chat reset button and logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const messages       = document.getElementById('messages');
   const inputForm      = document.getElementById('input-form');
   const userInput      = document.getElementById('user-input');
+  const resetBtn       = document.getElementById('reset-btn');
 
   // Foco inicial e armadilhas de foco do modal de consentimento
   const overlayFocusable = consentOverlay.querySelectorAll('input, button');
@@ -52,6 +53,18 @@ document.addEventListener('DOMContentLoaded', () => {
   let finished = false;
   let rulesLoaded = false;
 
+  function resetChat() {
+    messages.innerHTML = '';
+    redFlagIndex = 0;
+    pendingAnswers = 0;
+    finished = false;
+    userInput.value = '';
+    inputForm.style.display = 'block';
+    lgpdCheckbox.checked = false;
+    updateStartButton();
+    showConsentOverlay();
+  }
+
   // Carrega regras e disclaimer antes de iniciar o chat
   fetch('rules_otorrino.json')
     .then(r => r.json())
@@ -76,6 +89,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Exibe o overlay de consentimento ao carregar
   showConsentOverlay();
+
+  resetBtn.addEventListener('click', resetChat);
 
   // Ao aceitar LGPD e iniciar
   startBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
     </div>
   </div>
 
+  <button id="reset-btn" type="button">Reiniciar</button>
+
   <!-- Chat -->
   <main class="chat-container">
     <div id="messages" class="messages"></div>

--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,14 @@ body {
   padding: 0.5rem 1rem;
 }
 
+#reset-btn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.5rem 1rem;
+  z-index: 5;
+}
+
 /* Aumenta fonte em telas maiores (acessibilidade) */
 @media (min-width: 600px) {
   :root {


### PR DESCRIPTION
## Summary
- Add "Reiniciar" button to restart chat and show consent overlay again
- Implement `resetChat` to clear messages and restore state
- Style reset button for fixed top-right placement

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a08d4e3348832b8fcbe346e34222f7