### PR TITLE
Add loading indicator before consent flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const messages       = document.getElementById('messages');
   const inputForm      = document.getElementById('input-form');
   const userInput      = document.getElementById('user-input');
-  const resetBtn       = document.getElementById('reset-btn');
+    const resetBtn       = document.getElementById('reset-btn');
 
   // Foco inicial e armadilhas de foco do modal de consentimento
   const overlayFocusable = consentOverlay.querySelectorAll('input, button');
@@ -53,17 +53,22 @@ document.addEventListener('DOMContentLoaded', () => {
   let finished = false;
   let rulesLoaded = false;
 
-  function resetChat() {
-    messages.innerHTML = '';
-    redFlagIndex = 0;
-    pendingAnswers = 0;
-    finished = false;
-    userInput.value = '';
-    inputForm.style.display = 'block';
-    lgpdCheckbox.checked = false;
-    updateStartButton();
-    showConsentOverlay();
-  }
+    const loadingIndicator = document.createElement('div');
+    loadingIndicator.id = 'loading';
+    loadingIndicator.innerHTML = '<div class="spinner"></div><p>Carregando...</p>';
+    document.body.appendChild(loadingIndicator);
+
+    function resetChat() {
+      messages.innerHTML = '';
+      redFlagIndex = 0;
+      pendingAnswers = 0;
+      finished = false;
+      userInput.value = '';
+      inputForm.style.display = 'block';
+      lgpdCheckbox.checked = false;
+      updateStartButton();
+      showConsentOverlay();
+    }
 
   // Carrega regras e disclaimer antes de iniciar o chat
   fetch('rules_otorrino.json')
@@ -71,14 +76,16 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       rules = data;
       disclaimer = rules.legal?.disclaimer || '';
-      rulesLoaded = true;
-      updateStartButton();
     })
     .catch(() => {
       // Fallback simples caso o arquivo não seja encontrado
       disclaimer = 'As informações fornecidas não substituem avaliação médica.';
+    })
+    .finally(() => {
       rulesLoaded = true;
+      loadingIndicator.style.display = 'none';
       updateStartButton();
+      showConsentOverlay();
     });
 
   // Habilita botão Start somente se checkbox + regras carregadas
@@ -86,9 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
     startBtn.disabled = !(lgpdCheckbox.checked && rulesLoaded);
   }
   lgpdCheckbox.addEventListener('change', updateStartButton);
-
-  // Exibe o overlay de consentimento ao carregar
-  showConsentOverlay();
 
   resetBtn.addEventListener('click', resetChat);
 

--- a/styles.css
+++ b/styles.css
@@ -106,7 +106,7 @@ body {
   top: 0; left: 0;
   width: 100%; height: 100%;
   background: rgba(0,0,0,0.6);
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   z-index: 10;
@@ -136,6 +136,38 @@ body {
   right: 1rem;
   padding: 0.5rem 1rem;
   z-index: 5;
+}
+
+/* Indicador de carregamento */
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  z-index: 20;
+  font-size: 1.2rem;
+}
+
+#loading .spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Aumenta fonte em telas maiores (acessibilidade) */


### PR DESCRIPTION
## Summary
- display loading spinner before fetching rules and show consent overlay only after load completes
- hide consent overlay by default and add styles for loading indicator

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a08e959110832bbac390b3fe2fbc02