### PR TITLE
Handle array advice fields in non urgent advice

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,9 +169,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (redFlagIndex >= domainRules.red_flags.length) {
       // Nenhuma red flag positiva => orientação não urgente
-      const advice = domainRules.non_urgent_advice || {};
-      const summary = Array.isArray(advice.summary) ? advice.summary.join(' ') : advice.summary || '';
-      const safety = Array.isArray(advice.safety_net) ? advice.safety_net.join(' ') : advice.safety_net || '';
+      const summaryRaw = domainRules?.non_urgent_advice?.summary || '';
+      const safetyRaw = rules.domains?.[currentDomain]?.non_urgent_advice?.safety_net || '';
+      const summary = Array.isArray(summaryRaw) ? summaryRaw.join(' ') : summaryRaw;
+      const safety = Array.isArray(safetyRaw) ? safetyRaw.join(' ') : safetyRaw;
       appendMessage('bot', `${summary} ${safety}`);
       finished = true;
       return;


### PR DESCRIPTION
## Summary
- Convert `non_urgent_advice.summary` and `non_urgent_advice.safety_net` arrays to strings before display
- Fix safety net access to `rules.domains[currentDomain].non_urgent_advice.safety_net`

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0976d4e20832bbce9167e8b7a8c42