### PR TITLE
Add PDF export using jsPDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   </div>
 
   <button id="reset-btn" type="button">Reiniciar</button>
+  <button id="download-pdf-btn" type="button" style="display:none;">Baixar PDF</button>
 
   <!-- Chat -->
   <main class="chat-container">
@@ -33,6 +34,7 @@
     </form>
   </main>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add jsPDF via CDN and new download button
- generate PDF summary when conversation finishes

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a55d0288832ba7d0c905a8066b6f