### PR TITLE
Add post-chat feedback form

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const userInput      = document.getElementById('user-input');
   const resetBtn       = document.getElementById('reset-btn');
   const downloadPdfBtn = document.getElementById('download-pdf-btn');
+  const feedbackForm   = document.getElementById('feedback-form');
+  const feedbackComment= document.getElementById('feedback-comment');
+  const feedbackRating = document.getElementById('feedback-rating');
+
+  const FEEDBACK_ENDPOINT = '';
 
   // Foco inicial e armadilhas de foco do modal de consentimento
   const overlayFocusable = consentOverlay.querySelectorAll('input, button');
@@ -74,6 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
       updateStartButton();
       showConsentOverlay();
       downloadPdfBtn.style.display = 'none';
+      feedbackForm.style.display = 'none';
+      feedbackForm.reset();
     }
 
   // Carrega regras e disclaimer antes de iniciar o chat
@@ -105,6 +112,28 @@ document.addEventListener('DOMContentLoaded', () => {
     if (pdfDoc) {
       pdfDoc.save('triagem.pdf');
     }
+  });
+
+  feedbackForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {
+      comment: feedbackComment.value.trim(),
+      rating: feedbackRating.value,
+      timestamp: new Date().toISOString()
+    };
+    if (FEEDBACK_ENDPOINT) {
+      fetch(FEEDBACK_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      }).catch(console.error);
+    } else {
+      const stored = JSON.parse(localStorage.getItem('feedback') || '[]');
+      stored.push(data);
+      localStorage.setItem('feedback', JSON.stringify(stored));
+    }
+    feedbackForm.reset();
+    feedbackForm.style.display = 'none';
   });
 
   // Ao aceitar LGPD e iniciar
@@ -199,6 +228,7 @@ document.addEventListener('DOMContentLoaded', () => {
     finished = true;
     pdfDoc = buildPDF();
     downloadPdfBtn.style.display = 'inline';
+    feedbackForm.style.display = 'flex';
   }
 
   // Mostra até 3 perguntas de red flags por vez

--- a/index.html
+++ b/index.html
@@ -34,6 +34,20 @@
     </form>
   </main>
 
+  <form id="feedback-form" class="feedback" style="display:none;">
+    <label for="feedback-comment">Comentário</label>
+    <textarea id="feedback-comment" required></textarea>
+    <label for="feedback-rating">Nota</label>
+    <select id="feedback-rating">
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+      <option value="4">4</option>
+      <option value="5">5</option>
+    </select>
+    <button type="submit">Enviar feedback</button>
+  </form>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,25 @@ body {
   opacity: 0.6;
 }
 
+/* Formulário de feedback */
+.feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+  background: #fff;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.feedback textarea,
+.feedback select,
+.feedback button {
+  font-size: 1rem;
+  padding: 0.5rem;
+}
+
 /* Overlay de consentimento */
 .overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- display feedback form with comment and rating after triage finishes
- send feedback to configured endpoint or store in localStorage when no backend

## Testing
- `python validate_rules.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0b313c250832bbdc8dad68dddc607