### PR TITLE
Refactor chat flow with state machine and remove legacy features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ avaliação médica presencial.
      atendimento presencial imediato.
    - Caso todas as red flags sejam negativas, a aplicação apresenta um resumo e
      uma rede de segurança com orientações não urgentes.
-6. **PDF e feedback** – Ao final da conversa é possível baixar um PDF com as
-   respostas e enviar feedback com comentário e nota.
-7. **Reiniciar** – Um botão permite reiniciar a triagem a qualquer momento.
+6. **Reiniciar** – Um botão permite reiniciar a triagem a qualquer momento.
 
 ## Regras de Triagem (rules_otorrino.json)
 
@@ -39,7 +37,7 @@ avaliação médica presencial.
 
 - `index.html` – marcação HTML da interface.
 - `styles.css` – estilos visuais.
-- `app.js` – lógica de interação e geração do PDF.
+- `app.js` – lógica de interação do chat.
 - `rules_otorrino.json` – regras de triagem utilizadas pelo chat.
 - `validate_rules.py` – script para validar o arquivo de regras.
 

--- a/app.js
+++ b/app.js
@@ -1,302 +1,213 @@
 document.addEventListener('DOMContentLoaded', () => {
-  // Elementos de interface
+  const messages = document.getElementById('messages');
+  const quickReplies = document.getElementById('quick-replies');
+  const inputForm = document.getElementById('input-form');
+  const userInput = document.getElementById('user-input');
   const consentOverlay = document.getElementById('consent');
-  const startBtn       = document.getElementById('start-btn');
-  const lgpdCheckbox   = document.getElementById('lgpd-checkbox');
-  const messages       = document.getElementById('messages');
-  const inputForm      = document.getElementById('input-form');
-  const userInput      = document.getElementById('user-input');
-  const resetBtn       = document.getElementById('reset-btn');
-  const downloadPdfBtn = document.getElementById('download-pdf-btn');
-  const feedbackForm   = document.getElementById('feedback-form');
-  const feedbackComment= document.getElementById('feedback-comment');
-  const feedbackRating = document.getElementById('feedback-rating');
+  const startBtn = document.getElementById('start-btn');
+  const lgpdCheckbox = document.getElementById('lgpd-checkbox');
+  const themeToggle = document.getElementById('theme-toggle');
+  const resetBtn = document.getElementById('reset-btn');
 
-  const FEEDBACK_ENDPOINT = '';
+  const LGPD_KEY = 'rob-accept-lgpd';
+  const THEME_KEY = 'otto-theme';
 
-  // Foco inicial e armadilhas de foco do modal de consentimento
-  const overlayFocusable = consentOverlay.querySelectorAll('input, button');
-  const firstOverlayEl = overlayFocusable[0];
-  const lastOverlayEl = overlayFocusable[overlayFocusable.length - 1];
+  let rules = null;
 
-  function trapOverlayTab(e) {
-    if (e.key !== 'Tab') return;
-    if (e.shiftKey && document.activeElement === firstOverlayEl) {
-      e.preventDefault();
-      lastOverlayEl.focus();
-    } else if (!e.shiftKey && document.activeElement === lastOverlayEl) {
-      e.preventDefault();
-      firstOverlayEl.focus();
+  class ChatState {
+    constructor() {
+      this.state = 'CONSENT';
+      this.domain = '';
+      this.flags = [];
+      this.flagIndex = 0;
+      this.currentFlag = null;
     }
   }
 
-  function maintainOverlayFocus(e) {
-    if (!consentOverlay.contains(e.target)) {
-      e.stopPropagation();
-      firstOverlayEl.focus();
-    }
-  }
+  let chat = new ChatState();
 
-  function showConsentOverlay() {
-    consentOverlay.style.display = 'flex';
-    firstOverlayEl.focus();
-    consentOverlay.addEventListener('keydown', trapOverlayTab);
-    document.addEventListener('focus', maintainOverlayFocus, true);
-  }
+  // Tema
+  const savedTheme = localStorage.getItem(THEME_KEY) || 'light';
+  document.documentElement.classList.toggle('dark', savedTheme === 'dark');
+  themeToggle.textContent = savedTheme === 'dark' ? '☀️' : '🌙';
+  themeToggle.addEventListener('click', () => {
+    const isDark = document.documentElement.classList.toggle('dark');
+    themeToggle.textContent = isDark ? '☀️' : '🌙';
+    localStorage.setItem(THEME_KEY, isDark ? 'dark' : 'light');
+  });
 
-  function hideConsentOverlay() {
-    consentOverlay.style.display = 'none';
-    consentOverlay.removeEventListener('keydown', trapOverlayTab);
-    document.removeEventListener('focus', maintainOverlayFocus, true);
-    userInput.focus();
-  }
-
-  // Regras e estado da conversa
-  let rules = {};
-  let disclaimer = '';
-  let redFlagIndex = 0;
-  let pendingAnswers = 0;
-  let finished = false;
-  let rulesLoaded = false;
-  let currentDomain = '';
-  let pdfDoc = null;
-
-    const loadingIndicator = document.createElement('div');
-    loadingIndicator.id = 'loading';
-    loadingIndicator.innerHTML = '<div class="spinner"></div><p>Carregando...</p>';
-    document.body.appendChild(loadingIndicator);
-
-    function resetChat() {
-      messages.innerHTML = '';
-      redFlagIndex = 0;
-      pendingAnswers = 0;
-      finished = false;
-      currentDomain = '';
-      pdfDoc = null;
-      userInput.value = '';
-      inputForm.style.display = 'block';
-      lgpdCheckbox.checked = false;
-      updateStartButton();
-      showConsentOverlay();
-      downloadPdfBtn.style.display = 'none';
-      feedbackForm.style.display = 'none';
-      feedbackForm.reset();
-    }
-
-  // Carrega regras e disclaimer antes de iniciar o chat
+  // Carrega regras apenas uma vez
   fetch('rules_otorrino.json')
     .then(r => r.json())
-    .then(data => {
-      rules = data;
-      disclaimer = rules.legal?.disclaimer || '';
-    })
-    .catch(() => {
-      // Fallback simples caso o arquivo não seja encontrado
-      disclaimer = 'As informações fornecidas não substituem avaliação médica.';
-    })
-    .finally(() => {
-      rulesLoaded = true;
-      loadingIndicator.style.display = 'none';
-      updateStartButton();
-      showConsentOverlay();
-    });
+    .then(data => { rules = data; });
 
-  // Habilita botão Start somente se checkbox + regras carregadas
-  function updateStartButton() {
-    startBtn.disabled = !(lgpdCheckbox.checked && rulesLoaded);
+  // Consentimento
+  function showConsent() { consentOverlay.style.display = 'flex'; }
+  function hideConsent() { consentOverlay.style.display = 'none'; }
+
+  if (localStorage.getItem(LGPD_KEY)) {
+    chat.state = 'INTAKE';
+    hideConsent();
+    botSay('Olá! Qual é a sua queixa principal?');
+  } else {
+    showConsent();
   }
-  lgpdCheckbox.addEventListener('change', updateStartButton);
 
-  resetBtn.addEventListener('click', resetChat);
-  downloadPdfBtn.addEventListener('click', () => {
-    if (pdfDoc) {
-      pdfDoc.save('triagem.pdf');
-    }
+  lgpdCheckbox.addEventListener('change', () => {
+    startBtn.disabled = !lgpdCheckbox.checked;
+    startBtn.classList.toggle('opacity-50', !lgpdCheckbox.checked);
   });
 
-  feedbackForm.addEventListener('submit', e => {
-    e.preventDefault();
-    const data = {
-      comment: feedbackComment.value.trim(),
-      rating: feedbackRating.value,
-      timestamp: new Date().toISOString()
-    };
-    if (FEEDBACK_ENDPOINT) {
-      fetch(FEEDBACK_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
-      }).catch(console.error);
-    } else {
-      const stored = JSON.parse(localStorage.getItem('feedback') || '[]');
-      stored.push(data);
-      localStorage.setItem('feedback', JSON.stringify(stored));
-    }
-    feedbackForm.reset();
-    feedbackForm.style.display = 'none';
-  });
-
-  // Ao aceitar LGPD e iniciar
   startBtn.addEventListener('click', () => {
-    hideConsentOverlay();
-    appendMessage('bot', 'Qual sua queixa?');
+    localStorage.setItem(LGPD_KEY, 'true');
+    hideConsent();
+    chat.state = 'INTAKE';
+    botSay('Olá! Qual é a sua queixa principal?');
   });
 
-  // Recebe a queixa do usuário
-  inputForm.addEventListener('submit', e => {
-    e.preventDefault();
-    if (finished) return;
+  function scrollToBottom() {
+    messages.scrollTop = messages.scrollHeight;
+  }
 
-    const text = userInput.value.trim();
-    if (!text) return;
-
-    appendMessage('user', text);
-    currentDomain = classifyDomain(text);
-    userInput.value = '';
-
-    // Após a queixa, prossegue para red flags
-    inputForm.style.display = 'none';
-    showNextQuestions();
-  });
-
-  // Adiciona mensagem ao chat com disclaimer no rodapé
-  function appendMessage(sender, text, extraNode = null) {
+  function renderUser(text) {
     const wrapper = document.createElement('div');
-    wrapper.className = `message ${sender}`;
-
+    wrapper.className = 'message user';
     const content = document.createElement('div');
     content.className = 'content';
     content.textContent = text;
     wrapper.appendChild(content);
-
-    if (extraNode) wrapper.appendChild(extraNode);
-
-    const disc = document.createElement('div');
-    disc.className = 'disclaimer';
-    disc.textContent = disclaimer;
-    wrapper.appendChild(disc);
-
     messages.appendChild(wrapper);
-    messages.scrollTop = messages.scrollHeight;
-    return wrapper;
+    scrollToBottom();
   }
 
-  // Classificação muito simples do domínio
-  function classifyDomain(text) {
-    const domains = {
-      ouvido:   ['ouvido', 'zumbido', 'auditivo', 'ouvidos'],
-      nariz:    ['nariz', 'sangramento', 'congestao', 'sinusite'],
-      garganta: ['garganta', 'dor de garganta', 'amigdala', 'tosse']
-    };
-    let detected = 'outro';
-    const lower = text.toLowerCase();
-    for (const [domain, keywords] of Object.entries(domains)) {
-      if (keywords.some(k => lower.includes(k))) {
-        detected = domain;
-        break;
-      }
-    }
-    appendMessage('bot', `Domínio identificado: ${detected}.`);
-    return detected;
+  function renderBot(text) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.textContent = text;
+    wrapper.appendChild(content);
+    messages.appendChild(wrapper);
+    scrollToBottom();
   }
 
-  function buildPDF() {
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-    const date = new Date().toLocaleString('pt-BR');
-    const userMsgs = Array.from(messages.querySelectorAll('.message.user .content'));
-    const queixa = userMsgs[0]?.textContent || '';
-    const responses = userMsgs.slice(1).map(m => m.textContent);
-
-    let y = 10;
-    doc.text(`Data: ${date}`, 10, y); y += 10;
-    doc.text(`Queixa: ${queixa}`, 10, y); y += 10;
-    doc.text(`Domínio: ${currentDomain}`, 10, y); y += 10;
-    doc.text('Respostas:', 10, y); y += 10;
-    responses.forEach(res => {
-      doc.text(`- ${res}`, 10, y);
-      y += 10;
-      if (y > 280) {
-        doc.addPage();
-        y = 10;
-      }
-    });
-    return doc;
+  function botSay(text) {
+    const temp = document.createElement('div');
+    temp.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'content';
+    content.textContent = 'digitando…';
+    temp.appendChild(content);
+    messages.appendChild(temp);
+    scrollToBottom();
+    setTimeout(() => {
+      temp.remove();
+      renderBot(text);
+    }, 500);
   }
 
-  function finishChat() {
-    finished = true;
-    pdfDoc = buildPDF();
-    downloadPdfBtn.style.display = 'inline';
-    feedbackForm.style.display = 'flex';
-  }
-
-  // Mostra até 3 perguntas de red flags por vez
-  function showNextQuestions() {
-    const domainRules = currentDomain && rules.domains ? rules.domains[currentDomain] : null;
-    if (!domainRules?.red_flags || finished) return;
-
-    if (redFlagIndex >= domainRules.red_flags.length) {
-      // Nenhuma red flag positiva => orientação não urgente
-      const summaryRaw = domainRules?.non_urgent_advice?.summary || '';
-      const safetyRaw = rules.domains?.[currentDomain]?.non_urgent_advice?.safety_net || '';
-      const summary = Array.isArray(summaryRaw) ? summaryRaw.join(' ') : summaryRaw;
-      const safety = Array.isArray(safetyRaw) ? safetyRaw.join(' ') : safetyRaw;
-      appendMessage('bot', `${summary} ${safety}`);
-      finishChat();
-      return;
-    }
-
-    const batch = domainRules.red_flags.slice(redFlagIndex, redFlagIndex + 3);
-    pendingAnswers = batch.length;
-
-    batch.forEach(flag => {
-      const btnContainer = document.createElement('div');
-      btnContainer.className = 'btn-group';
-
-      ['Sim', 'Não', 'Não sei'].forEach(choice => {
-        const btn = document.createElement('button');
-        btn.textContent = choice;
-        btn.addEventListener('click', () => {
-          if (btnContainer.dataset.answered || finished) return;
-
-          btnContainer.dataset.answered = 'true';
-          btnContainer.querySelectorAll('button').forEach(b => b.disabled = true);
-
-          appendMessage('user', choice);
-          handleAnswer(choice, flag);
-        });
-        btnContainer.appendChild(btn);
+  function renderQuickReplies(options) {
+    quickReplies.innerHTML = '';
+    options.forEach(opt => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'rounded border px-3 py-1';
+      btn.textContent = opt.label;
+      btn.addEventListener('click', () => {
+        quickReplies.querySelectorAll('button').forEach(b => b.disabled = true);
+        renderUser(opt.label);
+        quickReplies.innerHTML = '';
+        applyAnswer(opt.value);
       });
-
-      appendMessage('bot', flag.question, btnContainer);
+      quickReplies.appendChild(btn);
     });
-
-    redFlagIndex += batch.length;
+    scrollToBottom();
   }
 
-  // Trata a resposta de cada red flag
-  function handleAnswer(choice, flag) {
-    pendingAnswers--;
+  function classifyDomain(text) {
+    const map = rules?.logic?.domain_classification_keywords || {};
+    const lower = text.toLowerCase();
+    for (const [domain, keywords] of Object.entries(map)) {
+      if (keywords.some(k => lower.includes(k))) return domain;
+    }
+    return 'outro';
+  }
 
-    if (choice === 'Sim' && !finished) {
-      // Desabilita todos os botões remanescentes
-      document.querySelectorAll('.btn-group button').forEach(b => b.disabled = true);
-
-      const message = flag?.on_true?.message ? `${flag.on_true.message} Consulte presencialmente um especialista.` : 'Consulte presencialmente um especialista.';
-      appendMessage('bot', message);
-
-      const link = document.createElement('a');
-      link.href = 'https://www.google.com/search?q=emergencia%20otorrino';
-      link.target = '_blank';
-      link.textContent = 'Buscar "emergencia otorrino"';
-      appendMessage('bot', 'Sugerimos procurar atendimento presencial:', link);
-      finishChat();
+  function askNextFlag() {
+    if (chat.flagIndex >= chat.flags.length) {
+      chat.state = 'ADVICE';
+      showAdvice();
       return;
     }
+    chat.currentFlag = chat.flags[chat.flagIndex++];
+    botSay(chat.currentFlag.question);
+    const opts = (rules.logic?.answer_options || []).map(o => ({ label: o, value: o }));
+    renderQuickReplies(opts);
+  }
 
-    if (pendingAnswers === 0 && !finished) {
-      showNextQuestions();
+  function applyAnswer(value) {
+    if (chat.state !== 'ASK_FLAGS') return;
+    if (value === 'Sim') {
+      chat.state = 'ESCALATE';
+      escalate(chat.currentFlag);
+    } else {
+      askNextFlag();
     }
   }
+
+  function escalate(flag) {
+    const levels = rules.logic?.escalation_levels || {};
+    const level = levels[flag.urgency] || {};
+    const msg = `${flag.on_true?.message || ''} ${level.cta || ''}`.trim();
+    botSay(msg);
+    chat.state = 'END';
+  }
+
+  function showAdvice() {
+    const advice = rules.domains?.[chat.domain]?.non_urgent_advice;
+    if (advice) {
+      const summary = Array.isArray(advice.summary) ? advice.summary.join(' ') : (advice.summary || '');
+      const safety = Array.isArray(advice.safety_net) ? advice.safety_net.join(' ') : (advice.safety_net || '');
+      botSay(`${summary} ${safety}`.trim());
+    } else {
+      botSay('Sem orientações específicas. Procure um especialista se necessário.');
+    }
+    chat.state = 'END';
+  }
+
+  function handleIntake(text) {
+    chat.state = 'CLASSIFY';
+    chat.domain = classifyDomain(text);
+    botSay(`Domínio identificado: ${chat.domain}.`);
+    chat.flags = (rules?.global_red_flags || []).slice();
+    const domainFlags = rules?.domains?.[chat.domain]?.red_flags || [];
+    chat.flags = chat.flags.concat(domainFlags);
+    chat.flagIndex = 0;
+    chat.state = 'ASK_FLAGS';
+    setTimeout(askNextFlag, 600);
+  }
+
+  inputForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = userInput.value.trim();
+    if (!text) return;
+    renderUser(text);
+    userInput.value = '';
+    if (chat.state === 'INTAKE') {
+      handleIntake(text);
+    } else if (chat.state === 'ASK_FLAGS') {
+      applyAnswer(text);
+    }
+  });
+
+  function reset() {
+    messages.innerHTML = '';
+    quickReplies.innerHTML = '';
+    userInput.value = '';
+    chat = new ChatState();
+    localStorage.removeItem(LGPD_KEY);
+    showConsent();
+  }
+
+  resetBtn.addEventListener('click', reset);
 });

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
         <div class="flex justify-end space-x-2">
           <button id="reset-btn" type="button" aria-label="Reiniciar" class="p-2">↻</button>
           <button id="theme-toggle" type="button" aria-label="Alternar tema" class="p-2">🌙</button>
-          <button id="download-pdf-btn" type="button" aria-label="Baixar PDF" class="hidden p-2">Baixar PDF</button>
         </div>
       </header>
       <div id="legal-banner" class="bg-yellow-100 p-1 text-center text-xs">
@@ -51,21 +50,6 @@
     </div>
   </div>
 
-  <form id="feedback-form" class="feedback" style="display:none;">
-    <label for="feedback-comment">Comentário</label>
-    <textarea id="feedback-comment" required></textarea>
-    <label for="feedback-rating">Nota</label>
-    <select id="feedback-rating">
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
-      <option value="4">4</option>
-      <option value="5">5</option>
-    </select>
-    <button type="submit">Enviar feedback</button>
-  </form>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplify interface by removing PDF download and feedback form
- Introduce ChatState-based flow with consent, intake, classification, flags and advice
- Add typing indicator, quick replies and theme persistence in localStorage

## Testing
- `python3 validate_rules.py`

------
https://chatgpt.com/codex/tasks/task_e_68a10abc4c90832bb856e4adc9efd5a7