### PR TITLE
Add progress indicator for flag questions

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const lgpdCheckbox = document.getElementById('lgpd-checkbox');
   const themeToggle = document.getElementById('theme-toggle');
   const resetBtn = document.getElementById('reset-btn');
+  const progressBar = document.getElementById('progress');
 
   const LGPD_KEY = 'rob-accept-lgpd';
   const THEME_KEY = 'otto-theme';
@@ -190,6 +191,8 @@ document.addEventListener('DOMContentLoaded', () => {
       showAdvice();
       return;
     }
+    const progress = (chat.flagIndex + 1) / chat.flags.length;
+    progressBar.value = progress;
     chat.currentFlag = chat.flags[chat.flagIndex++];
     botSay(chat.currentFlag.question);
     const opts = (rules.logic?.answer_options || []).map(o => ({ label: o, value: o }));
@@ -212,6 +215,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const msg = `${flag.on_true?.message || ''} ${level.cta || ''}`.trim();
     botSay(msg);
     chat.state = 'END';
+    progressBar.value = 0;
   }
 
   function showAdvice() {
@@ -224,6 +228,7 @@ document.addEventListener('DOMContentLoaded', () => {
       botSay('Sem orientações específicas. Procure um especialista se necessário.');
     }
     chat.state = 'END';
+    progressBar.value = 0;
   }
 
   function handleIntake(text) {
@@ -255,6 +260,7 @@ document.addEventListener('DOMContentLoaded', () => {
     messages.innerHTML = '';
     quickReplies.innerHTML = '';
     userInput.value = '';
+    progressBar.value = 0;
     chat = new ChatState();
     messageHistory = [];
     lastQuickReplies = [];

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     </main>
 
     <footer class="sticky bottom-0 bg-white p-4 dark:bg-gray-800">
+      <progress id="progress" value="0" max="1" class="mb-2 w-full"></progress>
       <div id="quick-replies" class="mb-2 flex flex-wrap gap-2"></div>
       <form id="input-form" class="flex gap-2">
         <input id="user-input" type="text" aria-label="Mensagem do usuário" placeholder="Digite aqui..." autocomplete="off" class="flex-1 rounded border p-2" />


### PR DESCRIPTION
## Summary
- Display triage progress bar above quick reply buttons
- Update flag question routine to show percentage complete
- Reset progress indicator when chat ends or restarts

## Testing
- `python validate_rules.py && echo 'validate_rules.py: success'`


------
https://chatgpt.com/codex/tasks/task_e_68a122c9c0c0832b85f184fe99cb0f23