### PR TITLE
Add avatars and timestamps to chat messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,9 +66,9 @@ document.addEventListener('DOMContentLoaded', () => {
       messageHistory = data.messages || [];
       messageHistory.forEach(m => {
         if (m.sender === 'user') {
-          renderUser(m.text, false);
+          renderUser(m.text, false, m.time);
         } else {
-          renderBot(m.text, false);
+          renderBot(m.text, false, m.time);
         }
       });
       lastQuickReplies = data.quickReplies || [];
@@ -109,32 +109,64 @@ document.addEventListener('DOMContentLoaded', () => {
     messages.scrollTop = messages.scrollHeight;
   }
 
-  function renderUser(text, save = true) {
+  function renderUser(text, save = true, time = new Date().toLocaleTimeString()) {
     const wrapper = document.createElement('div');
     wrapper.className = 'message user';
+
+    const avatar = document.createElement('span');
+    avatar.className = 'avatar';
+    avatar.textContent = '🧑';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble';
+
     const content = document.createElement('div');
     content.className = 'content';
     content.textContent = text;
-    wrapper.appendChild(content);
+
+    const timestamp = document.createElement('span');
+    timestamp.className = 'timestamp';
+    timestamp.textContent = time;
+
+    bubble.appendChild(content);
+    bubble.appendChild(timestamp);
+    wrapper.appendChild(avatar);
+    wrapper.appendChild(bubble);
     messages.appendChild(wrapper);
     scrollToBottom();
     if (save) {
-      messageHistory.push({ sender: 'user', text });
+      messageHistory.push({ sender: 'user', text, time });
       saveChat();
     }
   }
 
-  function renderBot(text, save = true) {
+  function renderBot(text, save = true, time = new Date().toLocaleTimeString()) {
     const wrapper = document.createElement('div');
     wrapper.className = 'message bot';
+
+    const avatar = document.createElement('span');
+    avatar.className = 'avatar';
+    avatar.textContent = '🤖';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'bubble';
+
     const content = document.createElement('div');
     content.className = 'content';
     content.textContent = text;
-    wrapper.appendChild(content);
+
+    const timestamp = document.createElement('span');
+    timestamp.className = 'timestamp';
+    timestamp.textContent = time;
+
+    bubble.appendChild(content);
+    bubble.appendChild(timestamp);
+    wrapper.appendChild(avatar);
+    wrapper.appendChild(bubble);
     messages.appendChild(wrapper);
     scrollToBottom();
     if (save) {
-      messageHistory.push({ sender: 'bot', text });
+      messageHistory.push({ sender: 'bot', text, time });
       saveChat();
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -32,8 +32,30 @@ body {
 
 .message {
   display: flex;
-  flex-direction: column;
   margin-bottom: 1rem;
+  align-items: flex-end;
+}
+
+.message.user {
+  flex-direction: row-reverse;
+}
+
+.message .avatar {
+  font-size: 1.5rem;
+  margin: 0 0.5rem;
+}
+
+.bubble {
+  display: flex;
+  flex-direction: column;
+}
+
+.message.bot .bubble {
+  align-items: flex-start;
+}
+
+.message.user .bubble {
+  align-items: flex-end;
 }
 
 .message .content {
@@ -47,12 +69,16 @@ body {
 
 .message.bot .content {
   background: var(--bot-color);
-  align-self: flex-start;
 }
 
 .message.user .content {
   background: var(--user-color);
-  align-self: flex-end;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 0.25rem;
 }
 
 .message .disclaimer {


### PR DESCRIPTION
## Summary
- display user and bot avatars in chat messages
- append localized timestamps for each message and persist them
- style message layout for avatars and timestamps

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a131921bf8832bbdac5092fee0966d