### PR TITLE
Add animated typing indicator for bot messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -176,7 +176,14 @@ document.addEventListener('DOMContentLoaded', () => {
     temp.className = 'message bot';
     const content = document.createElement('div');
     content.className = 'content';
-    content.textContent = 'digitando…';
+    const indicator = document.createElement('div');
+    indicator.className = 'typing';
+    for (let i = 0; i < 3; i++) {
+      const dot = document.createElement('span');
+      dot.className = 'typing-dot';
+      indicator.appendChild(dot);
+    }
+    content.appendChild(indicator);
     temp.appendChild(content);
     messages.appendChild(temp);
     scrollToBottom();

--- a/styles.css
+++ b/styles.css
@@ -207,6 +207,37 @@ body {
   }
 }
 
+/* Indicador de digitação */
+.typing {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.typing-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  background: #999;
+  border-radius: 50%;
+  animation: blink 1.4s infinite both;
+}
+
+.typing-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes blink {
+  0%, 80%, 100% {
+    opacity: 0;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
 /* Aumenta fonte em telas maiores (acessibilidade) */
 @media (min-width: 600px) {
   :root {


### PR DESCRIPTION
## Summary
- replace static "digitando…" text with animated typing indicator
- add CSS animation for blinking dots

## Testing
- `python validate_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a13a5c78d8832b971c3cd944653ac7