### PR TITLE
Implement chat data retention policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ Por ser uma aplicação estática, basta abrir `index.html` em um navegador
 compatível. Para atualizar as regras, modifique `rules_otorrino.json` e valide o
 conteúdo com `python validate_rules.py`.
 
+## Política de retenção de dados
+
+- As informações do chat e o consentimento LGPD são armazenados apenas no
+  navegador do usuário.
+- Esses dados são preservados por até **30 dias**; depois desse período, ao
+  carregar a página, eles são removidos automaticamente.
+- O botão **Reiniciar** também limpa imediatamente todas as informações
+  armazenadas.
+

--- a/app.js
+++ b/app.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const THEME_KEY = 'otto-theme';
   const CHAT_KEY = 'otto-chat';
   const RULES_KEY = 'otto-rules';
+  const TIMESTAMP_KEY = 'otto-chat-ts';
+  const MAX_CHAT_AGE = 30 * 24 * 60 * 60 * 1000; // 30 dias
 
   let rules = null;
 
@@ -40,6 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
       quickReplies: lastQuickReplies
     };
     localStorage.setItem(CHAT_KEY, JSON.stringify(data));
+    localStorage.setItem(TIMESTAMP_KEY, Date.now().toString());
   }
 
   // Tema
@@ -87,7 +90,14 @@ document.addEventListener('DOMContentLoaded', () => {
   function showConsent() { consentOverlay.style.display = 'flex'; }
   function hideConsent() { consentOverlay.style.display = 'none'; }
 
-  const savedChat = localStorage.getItem(CHAT_KEY);
+  let savedChat = localStorage.getItem(CHAT_KEY);
+  const savedTimestamp = parseInt(localStorage.getItem(TIMESTAMP_KEY), 10);
+  if (savedTimestamp && Date.now() - savedTimestamp > MAX_CHAT_AGE) {
+    localStorage.removeItem(CHAT_KEY);
+    localStorage.removeItem(LGPD_KEY);
+    localStorage.removeItem(TIMESTAMP_KEY);
+    savedChat = null;
+  }
   if (savedChat) {
     try {
       const data = JSON.parse(savedChat);
@@ -351,6 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
     lastQuickReplies = [];
     localStorage.removeItem(LGPD_KEY);
     localStorage.removeItem(CHAT_KEY);
+    localStorage.removeItem(TIMESTAMP_KEY);
     showConsent();
   }
 


### PR DESCRIPTION
## Summary
- save chat history with a timestamp and purge after 30 days
- reset removes stored timestamp
- document local 30-day data retention policy

## Testing
- `python validate_rules.py`

------
https://chatgpt.com/codex/tasks/task_e_68a14d7a75d8832bb777d3a8a4f9dd9b