### PR TITLE
Improve accessibility for quick replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Por ser uma aplicação estática, basta abrir `index.html` em um navegador
 compatível. Para atualizar as regras, modifique `rules_otorrino.json` e valide o
 conteúdo com `python validate_rules.py`.
 
+## Boas práticas de acessibilidade
+
+- Botões de respostas rápidas possuem atributos `aria-label` descritivos.
+- Todas as opções podem ser navegadas via teclado (Tab) e selecionadas com **Enter** ou **Espaço**.
+- Recomenda-se testar a interface com leitores de tela como [NVDA](https://www.nvaccess.org/) ou VoiceOver.
+- Ao adicionar novos componentes, mantenha contraste e semântica adequados.
+
 ## Política de retenção de dados
 
 - As informações do chat e o consentimento LGPD são armazenados apenas no

--- a/app.js
+++ b/app.js
@@ -242,6 +242,15 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.type = 'button';
       btn.className = 'rounded border px-3 py-1';
       btn.textContent = opt.label;
+      // Acessibilidade: rótulo e navegação por teclado
+      btn.setAttribute('aria-label', opt.ariaLabel || opt.label);
+      btn.tabIndex = 0;
+      btn.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          btn.click();
+        }
+      });
       btn.addEventListener('click', () => {
         quickReplies.querySelectorAll('button').forEach(b => b.disabled = true);
         renderUser(opt.label);
@@ -256,6 +265,8 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       quickReplies.appendChild(btn);
     });
+    const firstBtn = quickReplies.querySelector('button');
+    if (firstBtn) firstBtn.focus();
     scrollToBottom();
     saveChat();
   }


### PR DESCRIPTION
## Summary
- enhance quick reply buttons with descriptive `aria-label`s and keyboard handlers
- focus first quick reply and allow Enter/Space activation
- document accessibility best practices in README

## Testing
- `node --check app.js`
- `python validate_rules.py`
- `nvda --version` *(fails: command not found)*
- `VoiceOver` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a15b8567c8832ba826152d4f66946f