### PR TITLE
Compare downloaded rules against cached version

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,24 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch('rules_otorrino.json')
     .then(r => r.json())
     .then(data => {
+      const cachedStr = localStorage.getItem(RULES_KEY);
+      if (cachedStr) {
+        try {
+          const cachedData = JSON.parse(cachedStr);
+          if (
+            cachedData.version === data.version &&
+            cachedData.updated_at === data.updated_at
+          ) {
+            rules = cachedData;
+            return;
+          }
+          console.info('Cache de regras invalidado. Nova versão detectada.');
+        } catch (e) {
+          console.warn('Erro ao analisar cache de regras. Substituindo por nova versão.', e);
+        }
+      }
       rules = data;
+      localStorage.removeItem(RULES_KEY);
       localStorage.setItem(RULES_KEY, JSON.stringify(data));
     })
     .catch(err => {


### PR DESCRIPTION
## Summary
- Compare cached rule metadata with freshly fetched rules
- Invalidate and replace localStorage rule cache when version or updated_at differ
- Log cache invalidation events for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16e33cf8c832b9aea1ed32cb9af8a