### PR TITLE
Preprocess domain keywords and refactor classification

### DIFF
--- a/classifier.js
+++ b/classifier.js
@@ -1,0 +1,74 @@
+function normalize(str) {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function levenshtein(a, b) {
+  const matrix = Array.from({ length: b.length + 1 }, () => []);
+  for (let i = 0; i <= b.length; i++) matrix[i][0] = i;
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      const cost = b[i - 1] === a[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return matrix[b.length][a.length];
+}
+
+function similarity(a, b) {
+  const dist = levenshtein(a, b);
+  return 1 - dist / Math.max(a.length, b.length);
+}
+
+function preprocessDomainKeywords(rules) {
+  const map = rules?.logic?.domain_classification_keywords || {};
+  const processed = {};
+  for (const [domain, keywords] of Object.entries(map)) {
+    const entry = { regex: [], words: [] };
+    for (const kw of keywords) {
+      if (kw.startsWith('/') && kw.endsWith('/')) {
+        entry.regex.push(new RegExp(kw.slice(1, -1), 'i'));
+      } else {
+        entry.words.push(normalize(kw));
+      }
+    }
+    processed[domain] = entry;
+  }
+  rules._domainKeywords = processed;
+}
+
+function classifyDomain(text, r = rules) {
+  const map = r?._domainKeywords || {};
+  const normText = normalize(text);
+  const tokens = normText.split(/\s+/);
+  let best = { domain: 'outro', score: 0 };
+  for (const [domain, entry] of Object.entries(map)) {
+    for (const re of entry.regex) {
+      if (re.test(normText)) return { domain, confidence: 1 };
+    }
+    for (const kw of entry.words) {
+      if (normText.includes(kw)) return { domain, confidence: 1 };
+      for (const word of tokens) {
+        const score = similarity(word, kw);
+        if (score > best.score) best = { domain, score };
+      }
+    }
+  }
+  return { domain: best.domain, confidence: best.score };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    preprocessDomainKeywords,
+    classifyDomain,
+    normalize,
+    similarity,
+  };
+}

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
     </div>
   </div>
 
+  <script src="classifier.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,35 @@
+import json
+import subprocess
+from textwrap import dedent
+
+
+def run_node(code: str):
+    result = subprocess.run(
+        ["node", "-e", code], capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def test_classify_domain_basic():
+    script = dedent(
+        """
+        const { preprocessDomainKeywords, classifyDomain } = require('./classifier.js');
+        const rules = { logic: { domain_classification_keywords: {
+            ouvido: ['ouvido', '/ouvid[oa]\\s*dor/'],
+            nariz: ['nariz']
+        }}};
+        preprocessDomainKeywords(rules);
+        const r1 = classifyDomain('Tenho dor de ouvido', rules);
+        const r2 = classifyDomain('Sangue no nariz', rules);
+        const r3 = classifyDomain('nariss', rules);
+        console.log(JSON.stringify({r1, r2, r3}));
+        """
+    )
+    out = run_node(script)
+    data = json.loads(out)
+    assert data['r1']['domain'] == 'ouvido'
+    assert data['r1']['confidence'] == 1
+    assert data['r2']['domain'] == 'nariz'
+    assert data['r2']['confidence'] == 1
+    assert data['r3']['domain'] == 'nariz'
+    assert 0 < data['r3']['confidence'] < 1


### PR DESCRIPTION
## Summary
- Preprocess domain classification keywords once on rules load, compiling regexes and normalizing terms
- Refactor domain classification to use preprocessed structures via shared `classifier.js`
- Add tests validating classification behaviour and coverage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a17256ad58832bb62f763a129a8a61