### PR TITLE
Add optional self-care guidance to red flags

### DIFF
--- a/app.js
+++ b/app.js
@@ -333,7 +333,17 @@ document.addEventListener('DOMContentLoaded', () => {
   function escalate(flag) {
     const levels = rules.logic?.escalation_levels || {};
     const level = levels[flag.urgency] || {};
-    const msg = `${flag.on_true?.message || ''} ${level.cta || ''}`.trim();
+    const parts = [flag.on_true?.message];
+    if (flag.on_true?.self_care) {
+      const care = Array.isArray(flag.on_true.self_care)
+        ? flag.on_true.self_care.join(' ')
+        : flag.on_true.self_care;
+      parts.push(care);
+    }
+    if (level.cta) {
+      parts.push(level.cta);
+    }
+    const msg = parts.filter(Boolean).join(' ').trim();
     botSay(msg);
     chat.state = 'END';
     progressBar.value = 0;

--- a/rules_otorrino.json
+++ b/rules_otorrino.json
@@ -12,17 +12,54 @@
         "id": "admin",
         "title": "Dados administrativos",
         "fields": [
-          { "id": "visit_type", "label": "É consulta de acompanhamento ou primeira vez?", "type": "single_choice", "required": true, "choices": ["Primeira vez (sem presencial)", "Primeira vez somente em Telemedicina", "Acompanhamento clínico / Seguimento terapêutico (Telemedicina)"] },
-          { "id": "main_complaint", "label": "Queixa principal (texto livre)", "type": "text", "required": true },
-          { "id": "phone", "label": "Telefone celular (opcional)", "type": "text", "required": false }
+          {
+            "id": "visit_type",
+            "label": "É consulta de acompanhamento ou primeira vez?",
+            "type": "single_choice",
+            "required": true,
+            "choices": [
+              "Primeira vez (sem presencial)",
+              "Primeira vez somente em Telemedicina",
+              "Acompanhamento clínico / Seguimento terapêutico (Telemedicina)"
+            ]
+          },
+          {
+            "id": "main_complaint",
+            "label": "Queixa principal (texto livre)",
+            "type": "text",
+            "required": true
+          },
+          {
+            "id": "phone",
+            "label": "Telefone celular (opcional)",
+            "type": "text",
+            "required": false
+          }
         ]
       },
       {
         "id": "demographics",
         "title": "Demografia",
         "fields": [
-          { "id": "age", "label": "Idade", "type": "number", "required": false, "min": 0, "max": 120 },
-          { "id": "sex", "label": "Sexo (biológico)", "type": "single_choice", "required": false, "choices": ["Masculino", "Feminino", "Outro/Prefiro não dizer"] }
+          {
+            "id": "age",
+            "label": "Idade",
+            "type": "number",
+            "required": false,
+            "min": 0,
+            "max": 120
+          },
+          {
+            "id": "sex",
+            "label": "Sexo (biológico)",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Masculino",
+              "Feminino",
+              "Outro/Prefiro não dizer"
+            ]
+          }
         ]
       },
       {
@@ -35,66 +72,297 @@
             "type": "multi_choice",
             "required": true,
             "choices": [
-              "Febre", "Tosse", "Dor de cabeça", "Nariz entupido", "Coriza ou Catarro", "Mau cheiro",
-              "Redução do Olfato", "Redução do Paladar", "Pressão na face",
-              "Dor de Ouvido", "Sensação de ouvido tapado", "Coceira no ouvido",
-              "Dificuldade de ouvir", "Zumbido", "Tontura", "Sensação de Desmaio",
-              "Dor de Garganta", "Mau Hálito", "Sensação de Bolo na garganta",
-              "Dificuldade ou Desconforto para engolir", "Aumento dos gânglios do pescoço", "Roncos"
+              "Febre",
+              "Tosse",
+              "Dor de cabeça",
+              "Nariz entupido",
+              "Coriza ou Catarro",
+              "Mau cheiro",
+              "Redução do Olfato",
+              "Redução do Paladar",
+              "Pressão na face",
+              "Dor de Ouvido",
+              "Sensação de ouvido tapado",
+              "Coceira no ouvido",
+              "Dificuldade de ouvir",
+              "Zumbido",
+              "Tontura",
+              "Sensação de Desmaio",
+              "Dor de Garganta",
+              "Mau Hálito",
+              "Sensação de Bolo na garganta",
+              "Dificuldade ou Desconforto para engolir",
+              "Aumento dos gânglios do pescoço",
+              "Roncos"
             ]
           },
-          { "id": "had_before", "label": "Já teve esses sintomas antes?", "type": "single_choice", "required": false, "choices": ["Sim", "Não", "Talvez"] },
+          {
+            "id": "had_before",
+            "label": "Já teve esses sintomas antes?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não",
+              "Talvez"
+            ]
+          },
           {
             "id": "other_important_symptoms",
             "label": "Houve outros sintomas importantes (ex.: falta de ar, palpitação, dor muito intensa, turvação visual, sensação de desmaio, sangramento volumoso)?",
             "type": "single_choice",
             "required": true,
-            "choices": ["Sim", "Não"]
+            "choices": [
+              "Sim",
+              "Não"
+            ]
           },
-          { "id": "allergic_profile", "label": "Possui alergias a medicações ou outras substâncias?", "type": "single_choice", "required": true, "choices": ["Sim", "Não"] },
-          { "id": "allergic_detail", "label": "Se sim, quais?", "type": "text", "required": false },
-          { "id": "pain_scale", "label": "Intensidade do(s) sintoma(s) principal(is) (0–10)", "type": "scale", "required": true, "min": 0, "max": 10 }
+          {
+            "id": "allergic_profile",
+            "label": "Possui alergias a medicações ou outras substâncias?",
+            "type": "single_choice",
+            "required": true,
+            "choices": [
+              "Sim",
+              "Não"
+            ]
+          },
+          {
+            "id": "allergic_detail",
+            "label": "Se sim, quais?",
+            "type": "text",
+            "required": false
+          },
+          {
+            "id": "pain_scale",
+            "label": "Intensidade do(s) sintoma(s) principal(is) (0–10)",
+            "type": "scale",
+            "required": true,
+            "min": 0,
+            "max": 10
+          }
         ]
       },
       {
         "id": "history",
         "title": "Histórico clínico",
         "fields": [
-          { "id": "chronic_disease", "label": "Possui alguma doença crônica?", "type": "single_choice", "required": true, "choices": ["Hipertensão arterial", "Diabetes", "Hipotireoidismo/Hipertireoidismo", "Artrite reumatoide", "Lúpus", "Depressão", "Ansiedade", "Outros", "Nenhuma"] },
-          { "id": "cancer_history", "label": "Já teve algum câncer?", "type": "single_choice", "required": true, "choices": ["Sim", "Não"] },
-          { "id": "ent_surgery", "label": "Já fez cirurgia de ouvido, nariz ou garganta?", "type": "single_choice", "required": true, "choices": ["Sim", "Não"] },
-          { "id": "ent_surgery_detail", "label": "Se sim, qual?", "type": "text", "required": false },
-          { "id": "family_hearing_loss", "label": "Algum histórico de surdez na família?", "type": "single_choice", "required": false, "choices": ["Sim", "Não", "Outro"] }
+          {
+            "id": "chronic_disease",
+            "label": "Possui alguma doença crônica?",
+            "type": "single_choice",
+            "required": true,
+            "choices": [
+              "Hipertensão arterial",
+              "Diabetes",
+              "Hipotireoidismo/Hipertireoidismo",
+              "Artrite reumatoide",
+              "Lúpus",
+              "Depressão",
+              "Ansiedade",
+              "Outros",
+              "Nenhuma"
+            ]
+          },
+          {
+            "id": "cancer_history",
+            "label": "Já teve algum câncer?",
+            "type": "single_choice",
+            "required": true,
+            "choices": [
+              "Sim",
+              "Não"
+            ]
+          },
+          {
+            "id": "ent_surgery",
+            "label": "Já fez cirurgia de ouvido, nariz ou garganta?",
+            "type": "single_choice",
+            "required": true,
+            "choices": [
+              "Sim",
+              "Não"
+            ]
+          },
+          {
+            "id": "ent_surgery_detail",
+            "label": "Se sim, qual?",
+            "type": "text",
+            "required": false
+          },
+          {
+            "id": "family_hearing_loss",
+            "label": "Algum histórico de surdez na família?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não",
+              "Outro"
+            ]
+          }
         ]
       },
       {
         "id": "habits",
         "title": "Hábitos",
         "fields": [
-          { "id": "smoking", "label": "Você é tabagista?", "type": "single_choice", "required": false, "choices": ["Sim", "Não", "Outro"] },
-          { "id": "cigarettes_per_day", "label": "Se é tabagista, quantos cigarros/dia?", "type": "text", "required": false },
-          { "id": "alcohol_use", "label": "Usa bebida alcoólica?", "type": "single_choice", "required": false, "choices": ["Sim", "Não", "Outro"] }
+          {
+            "id": "smoking",
+            "label": "Você é tabagista?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não",
+              "Outro"
+            ]
+          },
+          {
+            "id": "cigarettes_per_day",
+            "label": "Se é tabagista, quantos cigarros/dia?",
+            "type": "text",
+            "required": false
+          },
+          {
+            "id": "alcohol_use",
+            "label": "Usa bebida alcoólica?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não",
+              "Outro"
+            ]
+          }
         ]
       },
       {
         "id": "meds",
         "title": "Medicações & anexos",
         "fields": [
-          { "id": "used_meds", "label": "Usou alguma medicação para os sintomas atuais?", "type": "single_choice", "required": false, "choices": ["Sim", "Não", "Outro"] },
-          { "id": "used_meds_detail", "label": "Se sim, qual?", "type": "text", "required": false },
-          { "id": "other_symptom_free_text", "label": "Outro sintoma que chamou atenção (texto breve)", "type": "text", "required": false },
-          { "id": "media_upload", "label": "Deseja enviar foto, vídeo ou áudio do problema?", "type": "single_choice", "required": false, "choices": ["Sim", "Não"] }
+          {
+            "id": "used_meds",
+            "label": "Usou alguma medicação para os sintomas atuais?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não",
+              "Outro"
+            ]
+          },
+          {
+            "id": "used_meds_detail",
+            "label": "Se sim, qual?",
+            "type": "text",
+            "required": false
+          },
+          {
+            "id": "other_symptom_free_text",
+            "label": "Outro sintoma que chamou atenção (texto breve)",
+            "type": "text",
+            "required": false
+          },
+          {
+            "id": "media_upload",
+            "label": "Deseja enviar foto, vídeo ou áudio do problema?",
+            "type": "single_choice",
+            "required": false,
+            "choices": [
+              "Sim",
+              "Não"
+            ]
+          }
         ]
       }
     ]
   },
   "global_red_flags": [
-    { "id": "global_airway_dyspnea", "question": "Há falta de ar importante ou dificuldade para respirar?", "rationale": "Sinal de comprometimento respiratório.", "urgency": "immediate", "on_true": { "action": "ESCALATE", "message": "🚑 Falta de ar importante: busque atendimento de emergência agora." } },
-    { "id": "global_heavy_bleeding", "question": "Há sangramento volumoso ou que não cessa?", "rationale": "Risco hemodinâmico em epistaxe ou outras causas.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Sangramento não controlado: procure atendimento presencial." } },
-    { "id": "global_very_intense_pain", "question": "A dor está muito intensa (por exemplo, 8, 9 ou 10 em 10)?", "rationale": "Dor desproporcional pode indicar complicação.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Dor muito intensa: avaliação presencial/teleconsulta prioritária." } },
-    { "id": "global_visual_blur", "question": "Há turvação visual nova ou piora súbita da visão?", "rationale": "Pode indicar complicações orbitárias/sistêmicas.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Alteração visual importante: procure avaliação presencial." } },
-    { "id": "global_presyncope_syncope", "question": "Houve sensação de desmaio ou desmaio?", "rationale": "Risco cardiovascular/neurológico.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Episódio de pré-síncope/síncope: avaliação presencial." } },
-    { "id": "global_palpitations", "question": "Houve palpitações importantes associadas aos sintomas?", "rationale": "Possível correlação cardiovascular.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Palpitações relevantes: agende avaliação prioritária." } }
+    {
+      "id": "global_airway_dyspnea",
+      "question": "Há falta de ar importante ou dificuldade para respirar?",
+      "rationale": "Sinal de comprometimento respiratório.",
+      "urgency": "immediate",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "🚑 Falta de ar importante: busque atendimento de emergência agora.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    },
+    {
+      "id": "global_heavy_bleeding",
+      "question": "Há sangramento volumoso ou que não cessa?",
+      "rationale": "Risco hemodinâmico em epistaxe ou outras causas.",
+      "urgency": "urgent",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "⚠️ Sangramento não controlado: procure atendimento presencial.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    },
+    {
+      "id": "global_very_intense_pain",
+      "question": "A dor está muito intensa (por exemplo, 8, 9 ou 10 em 10)?",
+      "rationale": "Dor desproporcional pode indicar complicação.",
+      "urgency": "urgent",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "⚠️ Dor muito intensa: avaliação presencial/teleconsulta prioritária.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    },
+    {
+      "id": "global_visual_blur",
+      "question": "Há turvação visual nova ou piora súbita da visão?",
+      "rationale": "Pode indicar complicações orbitárias/sistêmicas.",
+      "urgency": "urgent",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "⚠️ Alteração visual importante: procure avaliação presencial.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    },
+    {
+      "id": "global_presyncope_syncope",
+      "question": "Houve sensação de desmaio ou desmaio?",
+      "rationale": "Risco cardiovascular/neurológico.",
+      "urgency": "urgent",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "⚠️ Episódio de pré-síncope/síncope: avaliação presencial.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    },
+    {
+      "id": "global_palpitations",
+      "question": "Houve palpitações importantes associadas aos sintomas?",
+      "rationale": "Possível correlação cardiovascular.",
+      "urgency": "priority",
+      "on_true": {
+        "action": "ESCALATE",
+        "message": "⚠️ Palpitações relevantes: agende avaliação prioritária.",
+        "self_care": [
+          "Mantenha-se hidratado.",
+          "Evite esforços até ser avaliado."
+        ]
+      }
+    }
   ],
   "domains": {
     "ouvido": {
@@ -106,14 +374,118 @@
         "entrou água e agora dói"
       ],
       "red_flags": [
-        { "id": "ear_pain_drain_blood", "question": "Há dor intensa, secreção ou sangramento no ouvido?", "rationale": "Infecção complicada, perfuração, trauma.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Sinal de alerta no ouvido (dor/secreção/sangue). Procure avaliação presencial/teleconsulta prioritária." } },
-        { "id": "sudden_hearing_loss", "question": "A perda de audição começou de forma súbita (horas/dias) ou piorou muito rápido?", "rationale": "Emergência otológica.", "urgency": "immediate", "on_true": { "action": "ESCALATE", "message": "⚠️ Perda auditiva súbita/rápida: atendimento imediato." } },
-        { "id": "recurrent_vertigo", "question": "Você tem tontura/vertigem forte, recorrente ou contínua?", "rationale": "Causas periféricas/centrais exigem avaliação.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Tontura importante/recorrente: avaliação presencial." } },
-        { "id": "ear_deformity", "question": "Há deformidade na orelha (desde o nascimento ou após trauma)?", "rationale": "Requer avaliação especializada.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Deformidade auricular: encaminhamento prioritário." } },
-        { "id": "visible_blood_pus_foreign", "question": "Você vê sangue, pus, rolha de cerúmen dura ou corpo estranho no ouvido?", "rationale": "Critério de encaminhamento.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Achado no conduto: não introduza objetos; procure avaliação." } },
-        { "id": "asymmetric_loss", "question": "A perda de audição é de um lado só ou mais forte em um ouvido?", "rationale": "Assimetria é red flag.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Perda auditiva assimétrica/unilateral: avaliação com otorrino." } },
-        { "id": "unilateral_pulsatile_tinnitus", "question": "O zumbido é apenas de um lado ou pulsa como batimento?", "rationale": "Zumbido unilateral/pulsátil é red flag.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Zumbido unilateral/pulsátil: avaliação prioritária." } },
-        { "id": "poor_speech_disc", "question": "Você entende mal a fala em um ouvido só, comparado ao outro?", "rationale": "Discriminação assimétrica é red flag.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Discriminação de fala assimétrica: avaliação com especialista." } }
+        {
+          "id": "ear_pain_drain_blood",
+          "question": "Há dor intensa, secreção ou sangramento no ouvido?",
+          "rationale": "Infecção complicada, perfuração, trauma.",
+          "urgency": "urgent",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Sinal de alerta no ouvido (dor/secreção/sangue). Procure avaliação presencial/teleconsulta prioritária.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "sudden_hearing_loss",
+          "question": "A perda de audição começou de forma súbita (horas/dias) ou piorou muito rápido?",
+          "rationale": "Emergência otológica.",
+          "urgency": "immediate",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Perda auditiva súbita/rápida: atendimento imediato.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "recurrent_vertigo",
+          "question": "Você tem tontura/vertigem forte, recorrente ou contínua?",
+          "rationale": "Causas periféricas/centrais exigem avaliação.",
+          "urgency": "urgent",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Tontura importante/recorrente: avaliação presencial.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "ear_deformity",
+          "question": "Há deformidade na orelha (desde o nascimento ou após trauma)?",
+          "rationale": "Requer avaliação especializada.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Deformidade auricular: encaminhamento prioritário.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "visible_blood_pus_foreign",
+          "question": "Você vê sangue, pus, rolha de cerúmen dura ou corpo estranho no ouvido?",
+          "rationale": "Critério de encaminhamento.",
+          "urgency": "urgent",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Achado no conduto: não introduza objetos; procure avaliação.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "asymmetric_loss",
+          "question": "A perda de audição é de um lado só ou mais forte em um ouvido?",
+          "rationale": "Assimetria é red flag.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Perda auditiva assimétrica/unilateral: avaliação com otorrino.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "unilateral_pulsatile_tinnitus",
+          "question": "O zumbido é apenas de um lado ou pulsa como batimento?",
+          "rationale": "Zumbido unilateral/pulsátil é red flag.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Zumbido unilateral/pulsátil: avaliação prioritária.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "poor_speech_disc",
+          "question": "Você entende mal a fala em um ouvido só, comparado ao outro?",
+          "rationale": "Discriminação assimétrica é red flag.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Discriminação de fala assimétrica: avaliação com especialista.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        }
       ],
       "non_urgent_advice": {
         "summary": [
@@ -135,7 +507,20 @@
         "sangue escorrendo pela narina"
       ],
       "red_flags": [
-        { "id": "epistaxis_uncontrolled", "question": "O sangramento NÃO parou após compressão firme por 10–15 minutos (e, se disponível, vasoconstritor)?", "rationale": "Falha de controle com medidas iniciais exige avaliação presencial.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Epistaxe não controlada: procure atendimento presencial." } }
+        {
+          "id": "epistaxis_uncontrolled",
+          "question": "O sangramento NÃO parou após compressão firme por 10–15 minutos (e, se disponível, vasoconstritor)?",
+          "rationale": "Falha de controle com medidas iniciais exige avaliação presencial.",
+          "urgency": "urgent",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Epistaxe não controlada: procure atendimento presencial.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        }
       ],
       "non_urgent_advice": {
         "summary": [
@@ -157,10 +542,62 @@
         "falta de ar e ruído ao respirar"
       ],
       "red_flags": [
-        { "id": "airway_obstruction", "question": "Você tem falta de ar importante, ruído para respirar (estridor) ou engasgos com dificuldade para respirar?", "rationale": "Obstrução de via aérea exige avaliação imediata.", "urgency": "immediate", "on_true": { "action": "ESCALATE", "message": "🚑 Sinais de obstrução de via aérea: procure emergência agora." } },
-        { "id": "severe_dysphagia_aspiration", "question": "Engolir líquidos ou alimentos provoca engasgos frequentes ou sensação de que 'vai para o pulmão'?", "rationale": "Risco de aspiração/complicações.", "urgency": "urgent", "on_true": { "action": "ESCALATE", "message": "⚠️ Disfagia/aspiração: avaliação presencial prioritária." } },
-        { "id": "persistent_hoarseness", "question": "Sua rouquidão persiste por várias semanas sem melhora?", "rationale": "Red flag oncológica; precisa laringoscopia.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Rouquidão persistente: agende avaliação para exame da laringe." } },
-        { "id": "suspected_malignancy", "question": "Perda de peso sem explicação, ferida na boca que não cicatriza ou um 'caroço' no pescoço?", "rationale": "Sinais de alerta para câncer de cabeça e pescoço.", "urgency": "priority", "on_true": { "action": "ESCALATE", "message": "⚠️ Sinais oncológicos: avaliação especializada prioritária." } }
+        {
+          "id": "airway_obstruction",
+          "question": "Você tem falta de ar importante, ruído para respirar (estridor) ou engasgos com dificuldade para respirar?",
+          "rationale": "Obstrução de via aérea exige avaliação imediata.",
+          "urgency": "immediate",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "🚑 Sinais de obstrução de via aérea: procure emergência agora.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "severe_dysphagia_aspiration",
+          "question": "Engolir líquidos ou alimentos provoca engasgos frequentes ou sensação de que 'vai para o pulmão'?",
+          "rationale": "Risco de aspiração/complicações.",
+          "urgency": "urgent",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Disfagia/aspiração: avaliação presencial prioritária.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "persistent_hoarseness",
+          "question": "Sua rouquidão persiste por várias semanas sem melhora?",
+          "rationale": "Red flag oncológica; precisa laringoscopia.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Rouquidão persistente: agende avaliação para exame da laringe.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        },
+        {
+          "id": "suspected_malignancy",
+          "question": "Perda de peso sem explicação, ferida na boca que não cicatriza ou um 'caroço' no pescoço?",
+          "rationale": "Sinais de alerta para câncer de cabeça e pescoço.",
+          "urgency": "priority",
+          "on_true": {
+            "action": "ESCALATE",
+            "message": "⚠️ Sinais oncológicos: avaliação especializada prioritária.",
+            "self_care": [
+              "Mantenha-se hidratado.",
+              "Evite esforços até ser avaliado."
+            ]
+          }
+        }
       ],
       "non_urgent_advice": {
         "summary": [
@@ -225,11 +662,24 @@
     },
     "pain_escalation_threshold": 8,
     "ask_batch_size": 3,
-    "answer_options": ["Sim", "Não", "Não sei"],
+    "answer_options": [
+      "Sim",
+      "Não",
+      "Não sei"
+    ],
     "escalation_levels": {
-      "immediate": { "label": "Emergência", "cta": "Procure pronto atendimento AGORA." },
-      "urgent":    { "label": "Urgente",    "cta": "Procure atendimento presencial/teleconsulta prioritária." },
-      "priority":  { "label": "Prioritário","cta": "Agende avaliação com prioridade." }
+      "immediate": {
+        "label": "Emergência",
+        "cta": "Procure pronto atendimento AGORA."
+      },
+      "urgent": {
+        "label": "Urgente",
+        "cta": "Procure atendimento presencial/teleconsulta prioritária."
+      },
+      "priority": {
+        "label": "Prioritário",
+        "cta": "Agende avaliação com prioridade."
+      }
     }
   },
   "ui_texts": {

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -51,3 +51,18 @@ def test_missing_answer_options_fail(tmp_path):
     data["logic"]["answer_options"] = ["Talvez"]
     path = write_temp(tmp_path, data)
     assert validate(path) is False
+
+
+def test_self_care_optional(tmp_path):
+    data = load_base()
+    # remove self_care from first flag; still valid
+    data["global_red_flags"][0]["on_true"].pop("self_care", None)
+    path = write_temp(tmp_path, data)
+    assert validate(path) is True
+
+
+def test_self_care_wrong_type_fail(tmp_path):
+    data = load_base()
+    data["global_red_flags"][0]["on_true"]["self_care"] = "beber agua"
+    path = write_temp(tmp_path, data)
+    assert validate(path) is False

--- a/validate_rules.py
+++ b/validate_rules.py
@@ -59,6 +59,26 @@ def validate_unique_redflag_ids(data: dict) -> List[str]:
     return []
 
 
+def validate_self_care(data: dict) -> List[str]:
+    """Valida o campo opcional self_care dentro de on_true."""
+    errors: List[str] = []
+
+    def check(flags: List[dict], prefix: str) -> None:
+      for idx, item in enumerate(flags):
+        on_true = item.get("on_true", {})
+        if "self_care" in on_true:
+          sc = on_true["self_care"]
+          if not isinstance(sc, list) or not all(isinstance(x, str) for x in sc):
+            errors.append(
+                f"{prefix}[{idx}].on_true.self_care deve ser lista de strings")
+
+    check(data.get("global_red_flags", []), "global_red_flags")
+    for domain_name, domain in data.get("domains", {}).items():
+      check(domain.get("red_flags", []), f"domains.{domain_name}.red_flags")
+
+    return errors
+
+
 def validate_logic(data: dict) -> List[str]:
     """Valida regras específicas de lógica."""
     errors: List[str] = []
@@ -88,6 +108,7 @@ def validate(path: Path) -> bool:
         validate_required_keys,
         validate_logic,
         validate_unique_redflag_ids,
+        validate_self_care,
     )
     for validator in validators:
         errors.extend(validator(data))


### PR DESCRIPTION
## Summary
- add `self_care` guidance lists to every red flag in rules
- display self-care tips in `escalate` output
- validate optional `self_care` structure and add tests

## Testing
- `python validate_rules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a17799f70c832b9b6a8cd0557ce709