### PR TITLE
refactor: require explicit rules for classifyDomain

### DIFF
--- a/app.js
+++ b/app.js
@@ -414,7 +414,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleIntake(text) {
     chat.state = 'CLASSIFY';
-    const result = classifyDomain(text);
+    const result = classifyDomain(text, rules);
     if (result.domain === 'outro' || result.confidence < 0.4) {
       botSay('Não consegui identificar o domínio. Pode explicar melhor?');
       chat.state = 'INTAKE';

--- a/classifier.js
+++ b/classifier.js
@@ -44,7 +44,7 @@ function preprocessDomainKeywords(rules) {
   rules._domainKeywords = processed;
 }
 
-function classifyDomain(text, r = rules) {
+function classifyDomain(text, r) {
   const map = r?._domainKeywords || {};
   const normText = normalize(text);
   const tokens = normText.split(/\s+/);


### PR DESCRIPTION
## Summary
- remove default rules parameter from `classifyDomain`
- pass rules explicitly in intake handler

## Testing
- `pytest tests/test_classifier.py`
- `node -e "const { preprocessDomainKeywords, classifyDomain } = require('./classifier.js'); const rules = { logic: { domain_classification_keywords: { ouvido: ['ouvido'], nariz: ['nariz']}}}; preprocessDomainKeywords(rules); console.log(JSON.stringify({ouvido: classifyDomain('Tenho dor de ouvido', rules), nariz: classifyDomain('nariz entupido', rules)}));"`


------
https://chatgpt.com/codex/tasks/task_e_68a17e50207c832bb343b41dddbb2d5b