### PR TITLE
Add empathetic messaging and centralize strings

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function beginIntake() {
     chat.state = 'INTAKE';
     saveChat();
-    botSay('Olá! Qual é a sua queixa principal?');
+    botSay(messages.greeting);
   }
 
   function renderSymptoms() {
@@ -182,7 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chat.state = 'INTAKE';
       hideConsent();
       saveChat();
-      botSay('Olá! Qual é a sua queixa principal?');
+      botSay(messages.greeting);
     } else {
       showConsent();
     }
@@ -437,14 +437,14 @@ document.addEventListener('DOMContentLoaded', () => {
     chat.state = 'CLASSIFY';
     const result = classifyDomain(text, rules);
     if (result.domain === 'outro' || result.confidence < 0.4) {
-      botSay('Não consegui identificar o domínio. Pode explicar melhor?');
+      botSay(messages.classificationError);
       chat.state = 'INTAKE';
       return;
     }
     if (result.confidence < 0.7) {
       chat.proposedDomain = result.domain;
       chat.state = 'CONFIRM_DOMAIN';
-      botSay(`Você quis dizer algo relacionado a ${chat.proposedDomain}?`);
+      botSay(messages.confirmDomain(chat.proposedDomain));
       renderQuickReplies([
         { label: 'Sim', value: 'Sim' },
         { label: 'Não', value: 'Não' }
@@ -473,7 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (value.toLowerCase() === 'sim') {
       finalizeDomain(chat.proposedDomain);
     } else {
-      botSay('Tudo bem, descreva novamente sua queixa principal.');
+      botSay(messages.askAgain);
       chat.state = 'INTAKE';
     }
   }

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
   </div>
 
   <script src="classifier.js"></script>
+  <script src="messages.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/messages.js
+++ b/messages.js
@@ -1,0 +1,7 @@
+const messages = {
+  greeting: 'Olá! Entendo como isso pode ser desconfortável. Qual é a sua queixa principal?',
+  classificationError: 'Sinto muito, não consegui identificar o domínio. Entendo como isso pode ser desconfortável. Poderia explicar melhor?',
+  confirmDomain: (domain) => `Entendo como isso pode ser desconfortável. Você quis dizer algo relacionado a ${domain}?`,
+  askAgain: 'Tudo bem, descreva novamente sua queixa principal. Entendo como isso pode ser desconfortável e estou aqui para ajudar.'
+};
+


### PR DESCRIPTION
## Summary
- add messages.js to centralize key user-facing phrases
- revise app.js to use empathetic tone for greetings, classification errors, and confirmations
- load messages.js in index.html for easier future tone updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1d20d3d24832b8ac9e3a2b6339c9c