### PR TITLE
feat: add symptom guidelines validation and rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -206,7 +206,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (selected.length) {
       selected.forEach(sym => {
         const txt = rules?.guidelines?.[sym];
-        if (txt) botSay(txt);
+        if (txt) {
+          botSay(`Para ${sym}: ${txt}`);
+        }
       });
     }
     if (chat.pendingIntake) {

--- a/rules_otorrino.json
+++ b/rules_otorrino.json
@@ -634,7 +634,7 @@
     "Febre": "Mantenha-se hidratado e procure avaliação se durar mais de 3 dias.",
     "Tosse": "Beba água e evite ambientes com fumaça.",
     "Dor de cabeça": "Descanse em local calmo; procure atendimento se intensa ou persistente.",
-    "Nariz entupido": "Lave o nariz com soro fisiológico.",
+    "Nariz entupido": "Use solução salina para aliviar o entupimento.",
     "Coriza ou Catarro": "Hidrate-se e assoe o nariz suavemente.",
     "Mau cheiro": "Pode indicar infecção; mantenha higiene e procure médico se persistente.",
     "Redução do Olfato": "Evite substâncias irritantes; busque avaliação se não melhorar.",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -89,3 +89,10 @@ def test_empty_guideline_fail(tmp_path):
     data["guidelines"][sym] = ""
     path = write_temp(tmp_path, data)
     assert validate(path) is False
+
+
+def test_missing_guidelines_block_fail(tmp_path):
+    data = load_base()
+    data.pop("guidelines", None)
+    path = write_temp(tmp_path, data)
+    assert validate(path) is False

--- a/validate_rules.py
+++ b/validate_rules.py
@@ -12,7 +12,15 @@ import json
 from pathlib import Path
 from typing import Iterable, List
 
-REQUIRED_KEYS = {"version", "locale", "legal", "intake", "domains", "logic"}
+REQUIRED_KEYS = {
+    "version",
+    "locale",
+    "legal",
+    "intake",
+    "domains",
+    "logic",
+    "guidelines",
+}
 REQUIRED_ANSWER_OPTIONS = {"Sim", "Não"}
 
 


### PR DESCRIPTION
## Summary
- require `guidelines` block in rules and validate each symptom has text
- test validator behaviour for missing guidelines block
- show user-friendly guideline messages after symptom selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d32c0de4832b9084cf600893040f