### PR TITLE
Rename messages DOM reference to messagesEl

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const messages = document.getElementById('messages');
+  const messagesEl = document.getElementById('messages');
   const quickReplies = document.getElementById('quick-replies');
   const inputForm = document.getElementById('input-form');
   const userInput = document.getElementById('user-input');
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function scrollToBottom() {
-    messages.scrollTop = messages.scrollHeight;
+    messagesEl.scrollTop = messagesEl.scrollHeight;
   }
 
   function renderUser(text, save = true, time = new Date().toLocaleTimeString()) {
@@ -258,7 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
     bubble.appendChild(timestamp);
     wrapper.appendChild(avatar);
     wrapper.appendChild(bubble);
-    messages.appendChild(wrapper);
+    messagesEl.appendChild(wrapper);
     scrollToBottom();
     if (save) {
       messageHistory.push({ sender: 'user', text, time });
@@ -289,7 +289,7 @@ document.addEventListener('DOMContentLoaded', () => {
     bubble.appendChild(timestamp);
     wrapper.appendChild(avatar);
     wrapper.appendChild(bubble);
-    messages.appendChild(wrapper);
+    messagesEl.appendChild(wrapper);
     scrollToBottom();
     if (save) {
       messageHistory.push({ sender: 'bot', text, time });
@@ -312,7 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     content.appendChild(indicator);
     temp.appendChild(content);
-    messages.appendChild(temp);
+    messagesEl.appendChild(temp);
     scrollToBottom();
     setTimeout(() => {
       temp.remove();
@@ -496,7 +496,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function reset() {
-    messages.innerHTML = '';
+    messagesEl.innerHTML = '';
     quickReplies.innerHTML = '';
     userInput.value = '';
     progressBar.value = 0;

--- a/tests/test_symptom_guidelines.py
+++ b/tests/test_symptom_guidelines.py
@@ -30,6 +30,6 @@ def test_multiple_symptom_guidelines():
     messages = json.loads(out)
     assert messages == [
         'Beba água e evite ambientes com fumaça.',
-        'Lave o nariz com soro fisiológico.',
+        'Use solução salina para aliviar o entupimento.',
         'Reduza cafeína e álcool; procure otorrino se persistente.'
     ]


### PR DESCRIPTION
## Summary
- rename DOM element reference to `messagesEl` and update all uses
- align symptom guidelines test with latest rule text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb28d92c832b93fc83d415a55a8c