### PR TITLE
Require updated_at in rules validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ avaliação médica presencial.
 ## Regras de Triagem (rules_otorrino.json)
 
 - [rules_otorrino.json](./rules_otorrino.json) centraliza a lógica de triagem.
+- O arquivo deve conter o campo `updated_at`, utilizado para controle de versão
+  e cache.
 - Valide o arquivo executando `python validate_rules.py --path rules_otorrino.json`.
 - Ao atualizar o campo `updated_at`, revise o JSON e peça revisão clínica via
   PR dedicado.

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -39,6 +39,13 @@ def test_missing_top_level_key_fail(tmp_path):
     assert validate(path) is False
 
 
+def test_missing_updated_at_fail(tmp_path):
+    data = load_base()
+    data.pop("updated_at", None)
+    path = write_temp(tmp_path, data)
+    assert validate(path) is False
+
+
 def test_pain_threshold_out_of_range_fail(tmp_path):
     data = load_base()
     data["logic"]["pain_escalation_threshold"] = 11

--- a/validate_rules.py
+++ b/validate_rules.py
@@ -20,6 +20,7 @@ REQUIRED_KEYS = {
     "domains",
     "logic",
     "guidelines",
+    "updated_at",
 }
 REQUIRED_ANSWER_OPTIONS = {"Sim", "Não"}
 


### PR DESCRIPTION
## Summary
- require `updated_at` top-level key when validating rules
- fail validation when `updated_at` is missing
- document mandatory `updated_at` field in README

## Testing
- `python validate_rules.py --path rules_otorrino.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f23af0fc832b8330145dbdcb0b70