### PR TITLE
Update pytest requirement to 8.2 and ensure CI upgrades dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install --upgrade -r requirements.txt
       - name: Validate rules
         run: python validate_rules.py --path rules_otorrino.json
       - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest>=8.2


### PR DESCRIPTION
## Summary
- require pytest>=8.2
- upgrade dependencies in CI before tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f336cf5c832b8e6443fa97299577