### PR TITLE
Add symptom review shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const symptomForm = document.getElementById('symptom-form');
   const symptomOptions = document.getElementById('symptom-options');
   const skipSymptomsBtn = document.getElementById('skip-symptoms');
+  const reviewSymptomsBtn = document.getElementById('review-symptoms');
 
   const LGPD_KEY = 'rob-accept-lgpd';
   const THEME_KEY = 'otto-theme';
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let chat = new ChatState();
   let messageHistory = [];
   let lastQuickReplies = [];
+  let editingSymptoms = false;
 
   function saveChat() {
     const data = {
@@ -125,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
     botSay(messages.greeting);
   }
 
-  function renderSymptoms() {
+  function renderSymptoms(prefill = false) {
     const section = rules?.intake?.sections?.find(s => s.id === 'symptoms');
     const field = section?.fields?.find(f => f.id === 'symptom_checklist');
     if (!field) {
@@ -140,6 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
       input.type = 'checkbox';
       input.value = choice;
       input.name = 'symptom';
+      if (prefill && chat.symptoms.includes(choice)) input.checked = true;
       label.appendChild(input);
       const span = document.createElement('span');
       span.textContent = choice;
@@ -207,6 +210,10 @@ document.addEventListener('DOMContentLoaded', () => {
     symptomOverlay.style.display = 'none';
     chat.symptoms = selected;
     saveChat();
+    if (editingSymptoms) {
+      editingSymptoms = false;
+      return;
+    }
     if (chat.pendingIntake) {
       const pending = chat.pendingIntake;
       chat.pendingIntake = '';
@@ -222,6 +229,10 @@ document.addEventListener('DOMContentLoaded', () => {
     symptomOverlay.style.display = 'none';
     chat.symptoms = [];
     saveChat();
+    if (editingSymptoms) {
+      editingSymptoms = false;
+      return;
+    }
     if (chat.pendingIntake) {
       const pending = chat.pendingIntake;
       chat.pendingIntake = '';
@@ -231,6 +242,11 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       beginIntake();
     }
+  });
+
+  reviewSymptomsBtn.addEventListener('click', () => {
+    editingSymptoms = true;
+    renderSymptoms(true);
   });
 
   function scrollToBottom() {

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 
     <footer class="sticky bottom-0 bg-white p-4 dark:bg-gray-800">
       <progress id="progress" value="0" max="1" class="mb-2 w-full"></progress>
+      <button id="review-symptoms" type="button" aria-label="Revisar sintomas" class="mb-2 rounded border px-3 py-1">Revisar sintomas</button>
       <div id="quick-replies" class="mb-2 flex flex-wrap gap-2"></div>
       <form id="input-form" class="flex gap-2">
         <input id="user-input" type="text" aria-label="Mensagem do usuário" placeholder="Digite aqui..." autocomplete="off" class="flex-1 rounded border p-2" />


### PR DESCRIPTION
## Summary
- Add "Revisar sintomas" button in chat footer
- Pre-fill selected symptoms when reopening the symptom checklist
- Preserve chat flow and replace old symptom values on re-confirmation

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ff93efbc832ba11fedfd95daf03c