### PR TITLE
Simula envio ao médico quando endpoint não está configurado

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ avaliação médica presencial.
 - `rules_otorrino.json` – regras de triagem utilizadas pelo chat.
 - `validate_rules.py` – script para validar o arquivo de regras.
 
+## Envio de resultados
+
+Ao final da triagem, o botão **Enviar para médico** permite compartilhar o resumo:
+
+- Se a variável global `DOCTOR_ENDPOINT` estiver definida, os dados são enviados via requisição `POST` para esse endpoint.
+- Caso contrário, o envio é apenas simulado: é gerado um link `mailto:` com o resumo e um arquivo `triagem.json` é oferecido para download manual.
+- Nessa situação, uma mensagem informa ao usuário que o envio não foi feito automaticamente.
+
 ## Execução Local
 
 Por ser uma aplicação estática, basta abrir `index.html` em um navegador

--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const RULES_KEY = 'otto-rules';
   const TIMESTAMP_KEY = 'otto-chat-ts';
   const MAX_CHAT_AGE = 30 * 24 * 60 * 60 * 1000; // 30 dias
-  const DOCTOR_ENDPOINT = window.DOCTOR_ENDPOINT || '/api/send-results';
+  const DOCTOR_ENDPOINT = window.DOCTOR_ENDPOINT;
 
   let rules = null;
 
@@ -459,6 +459,32 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function sendResultsToDoctor(resumo) {
+    if (!DOCTOR_ENDPOINT) {
+      const json = JSON.stringify(resumo, null, 2);
+      const subject = encodeURIComponent('Resumo da triagem');
+      const body = encodeURIComponent(`Segue resumo da triagem:\n\n${json}`);
+
+      const mail = document.createElement('a');
+      mail.href = `mailto:?subject=${subject}&body=${body}`;
+      mail.style.display = 'none';
+      document.body.appendChild(mail);
+      mail.click();
+      document.body.removeChild(mail);
+
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const dl = document.createElement('a');
+      dl.href = url;
+      dl.download = 'triagem.json';
+      document.body.appendChild(dl);
+      dl.click();
+      document.body.removeChild(dl);
+      URL.revokeObjectURL(url);
+
+      botSay('Envio simulado. Um e-mail foi preparado e o arquivo pode ser baixado para compartilhar com um profissional.');
+      return;
+    }
+
     try {
       await fetch(DOCTOR_ENDPOINT, {
         method: 'POST',


### PR DESCRIPTION
## Resumo
- Verifica a existência de `DOCTOR_ENDPOINT` antes de enviar resultados
- Gera link de e-mail e download JSON quando não há endpoint
- Documenta no README o comportamento de envio ou simulação

## Testes
- `python validate_rules.py --path rules_otorrino.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ff96d450832b9f51cd419271f16b