### PR TITLE
feat: allow manual sharing of triage summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,21 @@ avaliação médica presencial.
 
 ## Envio de resultados
 
-Ao final da triagem, o botão **Enviar para médico** permite compartilhar o resumo:
+Ao final da triagem:
 
-- Se a variável global `DOCTOR_ENDPOINT` estiver definida, os dados são enviados via requisição `POST` para esse endpoint.
-- Caso contrário, o envio é apenas simulado: é gerado um link `mailto:` com o resumo e um arquivo `triagem.json` é oferecido para download manual.
-- Nessa situação, uma mensagem informa ao usuário que o envio não foi feito automaticamente.
+- Um resumo é salvo no navegador como `results-YYYYMMDD.json`. Se o armazenamento local falhar, o arquivo é baixado automaticamente.
+- O botão **Enviar para médico** abre um e-mail com o resumo. Enquanto não houver um backend real, o usuário deve compartilhar manualmente o arquivo gerado.
+
+### Recuperar e enviar manualmente
+
+1. Verifique se o arquivo `results-YYYYMMDD.json` foi baixado automaticamente.
+2. Caso contrário, recupere-o no `localStorage`:
+   - Abra as ferramentas de desenvolvedor do navegador.
+   - Acesse **Application/Armazenamento** > **Local Storage** e procure pela chave `results-YYYYMMDD.json`.
+   - Copie o valor e salve em um arquivo `.json`.
+3. Envie o arquivo ao médico por e-mail ou outro canal disponível.
+
+Se a variável global `DOCTOR_ENDPOINT` estiver definida, os dados também podem ser enviados automaticamente via requisição `POST` para esse endpoint.
 
 ## Execução Local
 

--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let messageHistory = [];
   let lastQuickReplies = [];
   let editingSymptoms = false;
+  let latestResultFile = '';
 
   function saveChat() {
     const data = {
@@ -230,10 +231,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   });
 
-  reviewSymptomsBtn.addEventListener('click', () => {
-    editingSymptoms = true;
-    renderSymptoms(true);
-  });
+  if (reviewSymptomsBtn) {
+    reviewSymptomsBtn.addEventListener('click', () => {
+      editingSymptoms = true;
+      renderSymptoms(true);
+    });
+  }
 
   function scrollToBottom() {
     messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -424,6 +427,27 @@ document.addEventListener('DOMContentLoaded', () => {
     progressBar.value = 0;
   }
 
+  function persistResults(resumo) {
+    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const file = `results-${date}.json`;
+    try {
+      localStorage.setItem(file, JSON.stringify(resumo));
+      latestResultFile = file;
+    } catch (e) {
+      const blob = new Blob([JSON.stringify(resumo, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = file;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      latestResultFile = file;
+    }
+    return file;
+  }
+
   function showAdvice() {
     const advice = rules.domains?.[chat.domain]?.non_urgent_advice;
     if (advice) {
@@ -448,6 +472,11 @@ document.addEventListener('DOMContentLoaded', () => {
       answers: chat.answers
     };
 
+    const fileName = persistResults(summary);
+    if (!DOCTOR_ENDPOINT) {
+      botSay(`Resumo salvo como ${fileName}. Baixe ou acesse este arquivo para enviar ao seu médico.`);
+    }
+
     quickReplies.innerHTML = '';
     const sendBtn = document.createElement('button');
     sendBtn.type = 'button';
@@ -462,9 +491,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function sendResultsToDoctor(resumo) {
     if (!DOCTOR_ENDPOINT) {
+      persistResults(resumo);
       const json = JSON.stringify(resumo, null, 2);
       const subject = encodeURIComponent('Resumo da triagem');
-      const body = encodeURIComponent(`Segue resumo da triagem:\n\n${json}`);
+      const body = encodeURIComponent(`Segue resumo da triagem.\n\n${json}\n\nAnexe o arquivo ${latestResultFile} ao compartilhar com o profissional de saúde.`);
 
       const mail = document.createElement('a');
       mail.href = `mailto:?subject=${subject}&body=${body}`;
@@ -473,17 +503,7 @@ document.addEventListener('DOMContentLoaded', () => {
       mail.click();
       document.body.removeChild(mail);
 
-      const blob = new Blob([json], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const dl = document.createElement('a');
-      dl.href = url;
-      dl.download = 'triagem.json';
-      document.body.appendChild(dl);
-      dl.click();
-      document.body.removeChild(dl);
-      URL.revokeObjectURL(url);
-
-      botSay('Envio simulado. Um e-mail foi preparado e o arquivo pode ser baixado para compartilhar com um profissional.');
+      botSay(`Envio simulado. Utilize o arquivo ${latestResultFile} para compartilhar os resultados com seu médico.`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- persist triage summaries in the browser and offer fallback download
- guide users on manually sharing results with doctors when backend is absent
- document manual recovery and sending of saved summaries

## Testing
- `python validate_rules.py --path rules_otorrino.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a20143c278832bace9c59c941237bb