### PR TITLE
feat: improve dark theme text colors

### DIFF
--- a/app.js
+++ b/app.js
@@ -230,10 +230,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   });
 
-  reviewSymptomsBtn.addEventListener('click', () => {
-    editingSymptoms = true;
-    renderSymptoms(true);
-  });
+  if (reviewSymptomsBtn) {
+    reviewSymptomsBtn.addEventListener('click', () => {
+      editingSymptoms = true;
+      renderSymptoms(true);
+    });
+  }
 
   function scrollToBottom() {
     messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -251,11 +253,11 @@ document.addEventListener('DOMContentLoaded', () => {
     bubble.className = 'flex flex-col items-end';
 
     const content = document.createElement('div');
-    content.className = 'w-fit max-w-[90%] rounded-lg bg-blue-300 p-3 leading-snug text-black';
+    content.className = 'w-fit max-w-[90%] rounded-lg bg-blue-300 p-3 leading-snug text-gray-900 dark:text-gray-100';
     content.textContent = text;
 
     const timestamp = document.createElement('span');
-    timestamp.className = 'mt-1 text-xs text-gray-600';
+    timestamp.className = 'mt-1 text-xs text-gray-600 dark:text-gray-400';
     timestamp.textContent = time;
 
     bubble.appendChild(content);
@@ -282,11 +284,11 @@ document.addEventListener('DOMContentLoaded', () => {
     bubble.className = 'flex flex-col items-start';
 
     const content = document.createElement('div');
-    content.className = 'w-fit max-w-[90%] rounded-lg bg-gray-100 p-3 leading-snug text-black';
+    content.className = 'w-fit max-w-[90%] rounded-lg bg-gray-100 p-3 leading-snug text-gray-900 dark:text-gray-100';
     content.textContent = text;
 
     const timestamp = document.createElement('span');
-    timestamp.className = 'mt-1 text-xs text-gray-600';
+    timestamp.className = 'mt-1 text-xs text-gray-600 dark:text-gray-400';
     timestamp.textContent = time;
 
     bubble.appendChild(content);
@@ -305,12 +307,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const temp = document.createElement('div');
     temp.className = 'mb-4 flex items-end';
     const content = document.createElement('div');
-    content.className = 'w-fit max-w-[90%] rounded-lg bg-gray-100 p-3 leading-snug text-black';
+    content.className = 'w-fit max-w-[90%] rounded-lg bg-gray-100 p-3 leading-snug text-gray-900 dark:text-gray-100';
     const indicator = document.createElement('div');
     indicator.className = 'flex gap-1';
     for (let i = 0; i < 3; i++) {
       const dot = document.createElement('span');
-      dot.className = 'h-2 w-2 rounded-full bg-gray-400 animate-[blink_1.4s_infinite_both]';
+      dot.className = 'h-2 w-2 rounded-full bg-gray-400 dark:bg-gray-600 animate-[blink_1.4s_infinite_both]';
       dot.style.animationDelay = `${i * 0.2}s`;
       indicator.appendChild(dot);
     }

--- a/index.html
+++ b/index.html
@@ -12,21 +12,21 @@
       }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-gray-900">
+<body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
   <div class="mx-auto flex min-h-screen w-full max-w-md flex-col">
     <div class="sticky top-0 z-50">
-      <header class="grid grid-cols-3 items-center bg-white p-4 dark:bg-gray-800">
+      <header class="grid grid-cols-3 items-center bg-white p-4 text-gray-900 dark:bg-gray-800 dark:text-gray-100">
         <div class="flex items-center space-x-2">
           <span aria-hidden="true" class="text-2xl">🩺</span>
-          <span class="font-semibold">OTTO</span>
+          <span class="font-semibold text-gray-900 dark:text-gray-100">OTTO</span>
         </div>
-        <h1 class="text-center text-sm font-bold">OTTO – Triagem ORL</h1>
+        <h1 class="text-center text-sm font-bold text-gray-900 dark:text-gray-100">OTTO – Triagem ORL</h1>
         <div class="flex justify-end space-x-2">
           <button id="reset-btn" type="button" aria-label="Reiniciar" class="p-2">↻</button>
           <button id="theme-toggle" type="button" aria-label="Alternar tema" class="p-2">🌙</button>
         </div>
       </header>
-      <div id="legal-banner" class="bg-yellow-100 p-1 text-center text-xs">
+      <div id="legal-banner" class="bg-yellow-100 p-1 text-center text-xs text-gray-900 dark:text-gray-100 dark:bg-yellow-800">
         Este aplicativo não substitui consulta médica.
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add global light/dark text colors to layout and header
- ensure fixed header, logo, and legal banner display correct dark-mode text
- update message rendering to inherit body text color and support dark mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a201d77fa8832b98c44b0162743776