### PR TITLE
feat: improve dark mode styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,11 +139,12 @@ document.addEventListener('DOMContentLoaded', () => {
     symptomOptions.innerHTML = '';
     field.choices.forEach(choice => {
       const label = document.createElement('label');
-      label.className = 'flex items-center space-x-2';
+      label.className = 'flex items-center space-x-2 dark:text-gray-100';
       const input = document.createElement('input');
       input.type = 'checkbox';
       input.value = choice;
       input.name = 'symptom';
+      input.className = 'rounded border dark:bg-gray-700 dark:border-gray-600';
       if (prefill && chat.symptoms.includes(choice)) input.checked = true;
       label.appendChild(input);
       const span = document.createElement('span');
@@ -230,10 +231,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   });
 
-  reviewSymptomsBtn.addEventListener('click', () => {
-    editingSymptoms = true;
-    renderSymptoms(true);
-  });
+  if (reviewSymptomsBtn) {
+    reviewSymptomsBtn.addEventListener('click', () => {
+      editingSymptoms = true;
+      renderSymptoms(true);
+    });
+  }
 
   function scrollToBottom() {
     messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -330,7 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
     options.forEach(opt => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'rounded border px-3 py-1';
+      btn.className = 'rounded border px-3 py-1 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600';
       btn.textContent = opt.label;
       // Acessibilidade: rótulo e navegação por teclado
       btn.setAttribute('aria-label', opt.ariaLabel || opt.label);
@@ -451,7 +454,7 @@ document.addEventListener('DOMContentLoaded', () => {
     quickReplies.innerHTML = '';
     const sendBtn = document.createElement('button');
     sendBtn.type = 'button';
-    sendBtn.className = 'rounded bg-green-600 px-3 py-1 text-white';
+    sendBtn.className = 'rounded bg-green-600 px-3 py-1 text-white dark:bg-green-700';
     sendBtn.textContent = 'Enviar para médico';
     sendBtn.addEventListener('click', () => {
       sendBtn.disabled = true;

--- a/index.html
+++ b/index.html
@@ -36,11 +36,11 @@
     </main>
 
     <footer class="sticky bottom-0 bg-white p-4 dark:bg-gray-800">
-      <progress id="progress" value="0" max="1" class="mb-2 w-full"></progress>
-      <button id="review-symptoms" type="button" aria-label="Revisar sintomas" class="mb-2 rounded border px-3 py-1">Revisar sintomas</button>
+      <progress id="progress" value="0" max="1" class="mb-2 w-full dark:bg-gray-700"></progress>
+      <button id="review-symptoms" type="button" aria-label="Revisar sintomas" class="mb-2 rounded border px-3 py-1 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600">Revisar sintomas</button>
       <div id="quick-replies" class="mb-2 flex flex-wrap gap-2"></div>
       <form id="input-form" class="flex gap-2">
-        <input id="user-input" type="text" aria-label="Mensagem do usuário" placeholder="Digite aqui..." autocomplete="off" class="flex-1 rounded border p-2" />
+        <input id="user-input" type="text" aria-label="Mensagem do usuário" placeholder="Digite aqui..." autocomplete="off" class="flex-1 rounded border p-2 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:placeholder-gray-400" />
         <button type="submit" aria-label="Enviar mensagem" class="rounded bg-blue-600 px-4 py-2 text-white">Enviar</button>
       </form>
     </footer>
@@ -62,7 +62,7 @@
       <h2 class="text-center text-sm font-semibold">Sintomas atuais</h2>
       <div id="symptom-options" class="max-h-60 overflow-y-auto space-y-2"></div>
       <div class="flex justify-end gap-2">
-        <button type="button" id="skip-symptoms" class="rounded border px-3 py-1">Pular</button>
+        <button type="button" id="skip-symptoms" class="rounded border px-3 py-1 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600">Pular</button>
         <button type="submit" class="rounded bg-blue-600 px-3 py-1 text-white">Continuar</button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- enhance dark theme for user input, progress bar, and buttons
- apply dark mode styles to dynamic quick replies and symptom checkboxes
- ensure doctor submission button respects dark mode

## Testing
- `python validate_rules.py --path rules_otorrino.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a201dc0988832bb7cd984dc0176d7f